### PR TITLE
Minor variable correction in tutorial_trees.rst

### DIFF
--- a/sdoc/tutorial/tutorial_trees.rst
+++ b/sdoc/tutorial/tutorial_trees.rst
@@ -365,7 +365,7 @@ between a given leaf and the tree root are visited.
 ::
 
    from ete3 import Tree
-   tree = Tree( "(A:1,(B:1,(C:1,D:1):0.5):0.5);" )
+   t = Tree( "(A:1,(B:1,(C:1,D:1):0.5):0.5);" )
     
    # Browse the tree from a specific leaf to the root
    node = t.search_nodes(name="C")[0]


### PR DESCRIPTION
Line 371 in [tutorial_trees.rst](https://github.com/etetoolkit/ete/blob/master/sdoc/tutorial/tutorial_trees.rst)
requires `tree` to be `t` in Line 368.