### PR TITLE
Minor change to get_topology method

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -382,8 +382,12 @@ class NCBITaxa(object):
             hit = 0
             visited = set()            
             start = prepostorder.index(root_taxid)
-            end = prepostorder.index(root_taxid, start+1)
-            subtree = prepostorder[start:end+1]
+            try:
+            	end = prepostorder.index(root_taxid, start+1)
+            	subtree = prepostorder[start:end+1]
+            except ValueError:
+            	subtree = []
+            	subtree.append(prepostorder[start])            
             leaves = set([v for v, count in Counter(subtree).items() if count == 1])
             nodes[root_taxid] = PhyloTree(name=str(root_taxid))
             current_parent = nodes[root_taxid]


### PR DESCRIPTION
If ValueError is raised,then the taxid represents a single node.Hence,a single-node annotated tree is returned from get_topology method.