### PR TITLE
Use HTTP protocol when downloading from NCBI FTP server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,4 @@ branches:
     - master
     - "3.0"
     - "2.3"
+    - /^feature\/.+$/

--- a/ete3/_ph.py
+++ b/ete3/_ph.py
@@ -43,10 +43,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 try:
-    from urllib2 import urlopen
+    from urllib2 import urlopen, URLError
     from urllib2 import quote as urlquote
 except ImportError:
-    from urllib.request import urlopen
+    from urllib.request import urlopen, URLError
     from urllib.parse import quote as urquote
 
 from six.moves import input
@@ -66,13 +66,13 @@ def call():
     try:
         f = urlopen('http://etetoolkit.org/static/et_phone_home.php?VERSION=%s&ID=%s'
                 %(__version__, __ETEID__))
-    except:
+    except URLError:
         print("No answer :(")
     else:
         print("Got answer!")
         try:
             f = urlopen('http://pypi.python.org/pypi/ete3/')
-        except:
+        except URLError:
             latest = None
         else:
             latest = int(f.read())
@@ -105,7 +105,7 @@ def call():
             try:
                 f = urlopen('http://etetoolkit.org/static/et_phone_home.php?VERSION=%s&ID=%s&MSG=%s'
                                 %(__version__, __ETEID__, msg))
-            except:
+            except URLError:
                 print("Message could be delivered :(")
             else:
                 print("Message delivered")
@@ -116,7 +116,7 @@ def new_version(module_name=None, current=None):
     try:
         f = urlopen('http://etetoolkit.org/releases/ete3/%s.latest'
                         %module_name)
-    except:
+    except URLError:
         latest = None
     else:
         latest = int(f.read())
@@ -135,7 +135,7 @@ def new_version(module_name=None, current=None):
 def read_content(address):
     try:
         f = urlopen(address)
-    except:
+    except URLError:
         return None
     else:
         return f.read()

--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -105,7 +105,7 @@ class NCBITaxa(object):
 
     def update_taxonomy_database(self, taxdump_file=None):
         """Updates the ncbi taxonomy database by downloading and parsing the latest
-        taxdump.tar.gz file from the NCBI FTP site.
+        taxdump.tar.gz file from the NCBI FTP site (via HTTP).
 
         :param None taxdump_file: an alternative location of the taxdump.tax.gz file.
         """
@@ -638,7 +638,7 @@ class NCBITaxa(object):
 
 def load_ncbi_tree_from_dump(tar):
     from .. import Tree
-    # Download: ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz
+    # Download: http://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz
     parent2child = {}
     name2node = {}
     node2taxname = {}
@@ -716,8 +716,8 @@ def update_db(dbfile, targz_file=None):
         except ImportError:
             from urllib.request import urlretrieve
 
-        print('Downloading taxdump.tar.gz from NCBI FTP site...', file=sys.stderr)
-        urlretrieve("ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz", "taxdump.tar.gz")
+        print('Downloading taxdump.tar.gz from NCBI FTP site (via HTTP)...', file=sys.stderr)
+        urlretrieve("http://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz", "taxdump.tar.gz")
         print('Done. Parsing...', file=sys.stderr)
         targz_file = "taxdump.tar.gz"
 

--- a/ete3/test/test_tree.py
+++ b/ete3/test/test_tree.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 import unittest
 import random
-import sys
-import time
 import itertools
 
 import sys

--- a/ete3/treeview/qt4_gui.py
+++ b/ete3/treeview/qt4_gui.py
@@ -54,7 +54,7 @@ except ImportError:
     USE_GL = False
 
 from . import _mainwindow, _search_dialog, _show_newick, _open_newick, _about
-from .main import TreeStyle, save, _leaf
+from .main import save, _leaf
 from .svg_colors import random_color
 from .qt4_render import render
 from .node_gui_actions import NewickDialog

--- a/examples/webplugin/wsgi/webplugin_example.py
+++ b/examples/webplugin/wsgi/webplugin_example.py
@@ -194,7 +194,7 @@ def search_by_feature(tree, search_term):
                 n.del_feature("bsize")
                 n.del_feature("shape")
                 n.del_feature("fgcolor")
-            except:
+            except (KeyError, AttributeError):
                 pass
     else:
         for n in tree.traverse():

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -64,7 +64,7 @@ md5_data = {
     'setuptools-0.6c9-py2.6.egg': 'ca37b1ff16fa2ede6e19383e7b59245a',
 }
 
-import sys, os
+import os
 try: from hashlib import md5
 except ImportError: from md5 import md5
 


### PR DESCRIPTION
NCBI seems to support both FTP as well as HTTP to download from their servers.

FTP is often problematic for users behind firewalls or proxies as reported in #193.
This pull request should fix #193 since HTTP proxies are supported. This was tested locally [using a simple HTTP proxy](https://wiki.python.org/moin/Twisted-Examples) and setting the following in the shell environment:

    export http_proxy=http://127.0.0.1:8080
    export https_proxy=https://127.0.0.1:8080

HTTPS support is not clear and requires further testing. I was not successful at downloading via HTTPS using this simple HTTP proxy.