### PR TITLE
quoted node names don't include the quotes

### DIFF
--- a/ete3/parser/newick.py
+++ b/ete3/parser/newick.py
@@ -262,7 +262,7 @@ def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
             else : # quoted text, add to dictionary and replace with reference
                 quoted_ref_id= _QUOTED_TEXT_PREFIX + str(counter/2)
                 unquoted_nw += quoted_ref_id
-                quoted_map[quoted_ref_id]=token
+                quoted_map[quoted_ref_id]=token[1:-1]  # without the quotes
         nw = unquoted_nw
 
     if nw.count('(') != nw.count(')'):

--- a/ete3/parser/newick.py
+++ b/ete3/parser/newick.py
@@ -264,7 +264,6 @@ def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
                 unquoted_nw += quoted_ref_id
                 quoted_map[quoted_ref_id]=token[1:-1]  # without the quotes
         nw = unquoted_nw
-        print(nw)
 
     if nw.count('(') != nw.count(')'):
         raise NewickError('Parentheses do not match. Broken tree structure?')

--- a/ete3/parser/newick.py
+++ b/ete3/parser/newick.py
@@ -264,6 +264,7 @@ def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
                 unquoted_nw += quoted_ref_id
                 quoted_map[quoted_ref_id]=token[1:-1]  # without the quotes
         nw = unquoted_nw
+        print(nw)
 
     if nw.count('(') != nw.count(')'):
         raise NewickError('Parentheses do not match. Broken tree structure?')
@@ -315,7 +316,7 @@ def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
     
     # references in node names are replaced with quoted text before returning
     if quoted_names:
-        for node in root_node.iter_descendants():
+        for node in root_node.traverse():
             if node.name.startswith(_QUOTED_TEXT_PREFIX):
                 node.name = quoted_map[node.name]
     

--- a/ete3/test/test_tree.py
+++ b/ete3/test/test_tree.py
@@ -236,7 +236,7 @@ class Test_Coretype_Tree(unittest.TestCase):
             self.assertRaises(NewickError, Tree, newick=nw)
             self.assertRaises(NewickError, Tree, newick=nw, quoted_node_names=True, format=0)
             t = Tree(newick=nw, format=1, quoted_node_names=True)
-            self.assertTrue(any(n for n in t if n.name == '"%s"'%complex_name))
+            self.assertTrue(any(n for n in t if n.name == '%s'%complex_name))
 
         
     def test_custom_formatting_formats(self):


### PR DESCRIPTION
quoted node names were including the quotes in the node name, which is not the behavior we want