### PR TITLE
do not ignore dbfile argument

### DIFF
--- a/ete3/tools/ete_ncbiquery.py
+++ b/ete3/tools/ete_ncbiquery.py
@@ -106,7 +106,7 @@ def run(args):
     if not args.tree and not args.info and not args.descendants:
         args.tree = True
 
-    ncbi = NCBITaxa()
+    ncbi = NCBITaxa(args.dbfile)
 
     all_taxids = {}
     all_names = set()


### PR DESCRIPTION
ete3 ncbiquery does not takes in account the --db taxa.sqlite file provided.
as the call to NCBITaxa is called with no value at init so does not use args.dbfile value

this simple patch allows to specify the dbfile to use 

Eric