### PR TITLE
allow creation of db file from local taxdump file + add create db option

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -74,18 +74,21 @@ class NCBITaxa(object):
     Provides a local transparent connector to the NCBI taxonomy database.
     """
 
-    def __init__(self, dbfile=None):
+    def __init__(self, dbfile=None, taxdump_file=None):
 
         if not dbfile:
             self.dbfile = os.path.join(os.environ.get('HOME', '/'), '.etetoolkit', 'taxa.sqlite')
         else:
             self.dbfile = dbfile
 
+        if taxdump_file:
+            self.update_taxonomy_database(taxdump_file)
+
         if dbfile is None and not os.path.exists(self.dbfile):
             print('NCBI database not present yet (first time used?)', file=sys.stderr)
-            self.update_taxonomy_database()
+            self.update_taxonomy_database(taxdump_file)
 
-        if not os.path.exists(self.dbfile):
+        if not os.path.exists(self.dbfile): 
             raise ValueError("Cannot open taxonomy database: %s" %self.dbfile)
 
         self.db = None
@@ -93,7 +96,7 @@ class NCBITaxa(object):
 
         if self.__get_db_version() != DB_VERSION:
             print('NCBI database format is outdated. Upgrading', file=sys.stderr)
-            self.update_taxonomy_database()
+            self.update_taxonomy_database(taxdump_file)
 
     def __get_db_version(self):
         try:
@@ -741,7 +744,10 @@ def update_db(dbfile, targz_file=None):
     except:
         raise
     else:
-        os.system("rm syn.tab merged.tab taxa.tab taxdump.tar.gz")
+        os.system("rm syn.tab merged.tab taxa.tab")
+        # remove only downloaded taxdump file 
+        if not targz_file:
+            os.system("rm taxdump.tar.gz")
 
 def upload_data(dbfile):
     print()

--- a/ete3/tools/ete_ncbiquery.py
+++ b/ete3/tools/ete_ncbiquery.py
@@ -56,6 +56,15 @@ def populate_args(ncbi_args_p):
                         type=str,
                         help="""NCBI sqlite3 db file.""")
 
+    ncbi_args.add_argument("--taxdump_file",  dest="taxdumpfile",
+                        type=str,
+                        help="""Use local NCBI taxdump file instead of downloading from NCBI.""")
+
+    ncbi_args.add_argument("--create",  dest="create",
+                        action='store_true', 
+                        default=False,
+                        help="""Create taxdump file and exit.""")
+
     ncbi_args.add_argument("--fuzzy", dest="fuzzy", type=float,
                         help=("EXPERIMENTAL: Tries a fuzzy (and SLOW) search for those"
                               " species names that could not be translated"
@@ -106,8 +115,11 @@ def run(args):
     if not args.tree and not args.info and not args.descendants:
         args.tree = True
 
-    ncbi = NCBITaxa(args.dbfile)
+        
+    ncbi = NCBITaxa(args.dbfile, args.taxdumpfile)
 
+    if args.create:
+        sys.exit(0)
     all_taxids = {}
     all_names = set()
     queries = []


### PR DESCRIPTION
We provide ete tools thru a centralized instalation on the HPC cluster.
compute node does not have internet access, so user can't create the db file (taxa.sqlite) using http ncbi access.

with this modifications, users can provide a local taxdump.tar.gz file and create their taxa.sqlite db.

furthermore we mirror taxonomy databases from the ncbi, with this modification we will be abble to update the taxa.sqlite on a centralised way and provide a up to date db to all our users.

regards

Eric 