### PR TITLE
Fix documentation for tree.render()

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1347,7 +1347,7 @@ class TreeNode(object):
         :var px units: "px": pixels, "mm": millimeters, "in": inches
         :var None h: height of the image in :attr:`units`
         :var None w: width of the image in :attr:`units`
-        :var 300 dpi: dots per inches.
+        :var 90 dpi: dots per inches.
 
         """
 


### PR DESCRIPTION
Previously, the documentation stated that the default dpi was 300, when it's actually 90. This change should correct the reference documentation.