### PR TITLE
Fix tree.render() documentation

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1350,7 +1350,7 @@ class TreeNode(object):
         :var px units: "px": pixels, "mm": millimeters, "in": inches
         :var None h: height of the image in :attr:`units`
         :var None w: width of the image in :attr:`units`
-        :var 300 dpi: dots per inches.
+        :var 90 dpi: dots per inches.
 
         """
 


### PR DESCRIPTION
Fixing tree.render() dpi description to accurately reflect the default value of 90 dpi.