### PR TITLE
fix tree.write() documentation

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -831,7 +831,7 @@ class TreeNode(object):
 
         ::
 
-             t.get_newick(features=["species","name"], format=1)
+             t.write(features=["species","name"], format=1)
 
         """
 


### PR DESCRIPTION
Example for tree.write() used old method. Is now updated.