### PR TITLE
Fix #342: cog supertree workflows die with sort key error in python 3.x

### DIFF
--- a/ete3/tools/ete_build_lib/task/cog_selector.py
+++ b/ete3/tools/ete_build_lib/task/cog_selector.py
@@ -77,6 +77,8 @@ class CogSelector(CogSelectorTask):
         self.cogs = None
 
     def finish(self):
+        def cog_size_comparator_key(c):
+            return (len(c), _min([sp2cogs[_sp] for _sp, _seq in c]))
         def sort_cogs_by_size(c1, c2):
             '''
             sort cogs by descending size. If two cogs are the same size, sort
@@ -96,6 +98,8 @@ class CogSelector(CogSelectorTask):
             else:
                 return r
 
+        def cog_sp_comparator_key(c):
+            return (_min([sp2cogs[_sp] for _sp, _seq in c]), sorted(c))
         def sort_cogs_by_sp_repr(c1, c2):
             c1_repr = _min([sp2cogs[_sp] for _sp, _seq in c1])
             c2_repr = _min([sp2cogs[_sp] for _sp, _seq in c2])
@@ -145,7 +149,7 @@ class CogSelector(CogSelectorTask):
             log.log(28, "% 20s  found in single copy in  % 6d (%0.1f%%) COGs " %(sp, ncogs, 100 * ncogs/float(cognumber)))
 
         valid_cogs = sorted([sing for sing in all_singletons if len(sing) >= min_species],
-                            sort_cogs_by_size)
+                            key=cog_size_comparator_key)
 
         log.log(28, "Largest cog size: %s. Smallest cog size: %s" %(
                 largest_cog, smallest_cog))

--- a/ete3/tools/ete_build_lib/task/concat_alg.py
+++ b/ete3/tools/ete_build_lib/task/concat_alg.py
@@ -244,6 +244,8 @@ def get_concatenated_alg(alg_filenames, models=None,
     log.info("%d out of %d will be kept (missing factor threshold=%g, %d species forced to kept)" %\
                  (len(valid_species), len(sp2alg), kill_thr, len(keep_species)))
 
+    def single_algs_comparator_key(alg):
+        return (alg.matrix, sorted(alg.id2name.values()))
     def sort_single_algs(alg1, alg2):
         r = cmp(alg1.matrix, alg2.matrix)
         if r == 0:
@@ -252,7 +254,7 @@ def get_concatenated_alg(alg_filenames, models=None,
         else:
             return r
 
-    sorted_algs = sorted(alg_objects, sort_single_algs)
+    sorted_algs = sorted(alg_objects, key=single_algs_comparator_key)
     concat_alg_lengths = [alg.seqlength for alg in sorted_algs]
     model2win = {}
     model2size = {}


### PR DESCRIPTION
Created comparator key functions for cog_selector.py:finish to replace
sort_cogs_by_size() and sort_cogs_by_sp_repr() and for
concat_alg.py:get_concatenated_alg to replace sort_single_algs()