### PR TITLE
Fix Python3/pyQt4 compatibility issues; bug in chi2 (ete_evol); faster prune

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1551,13 +1551,8 @@ class TreeNode(object):
         .. versionadded: 2.1
 
         Sort the branches of a given tree by node names. After the
-        tree is sorted, nodes are labeled in ascending order. This
-        can be used to ensure that nodes in a tree with the same node
-        names are always labeled in the same way. Note that if
-        duplicated names are present, extra criteria should be added
-        to sort nodes.
-
-        Unique id is stored as a node._nid attribute
+        tree is sorted. Note that if duplicated names are present,
+        extra criteria should be added to sort nodes.
 
         """
 

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -2469,15 +2469,15 @@ class TreeNode(object):
         from .. import _ph
         _ph.call()
 
-
 def _translate_nodes(root, *nodes):
     name2node = dict([ [n, None] for n in nodes if type(n) is str])
-    for n in root.traverse():
-        if n.name in name2node:
-            if name2node[n.name] is not None:
-                raise TreeError("Ambiguous node name: "+str(n.name))
-            else:
-                name2node[n.name] = n
+    if name2node:
+        for n in root.traverse():
+            if n.name in name2node:
+                if name2node[n.name] is not None:
+                    raise TreeError("Ambiguous node name: "+str(n.name))
+                else:
+                    name2node[n.name] = n
 
     if None in list(name2node.values()):
         notfound = [key for key, value in six.iteritems(name2node) if value is None]

--- a/ete3/evol/evoltree.py
+++ b/ete3/evol/evoltree.py
@@ -80,7 +80,12 @@ from warnings import warn
 from .. import PhyloNode, SeqGroup
 from ..parser.newick import write_newick
 from .model import Model, PARAMS, AVAIL
-from .utils import translate, chi_high
+from .utils import translate
+try:
+    from scipy.stats import chi2
+    chi_high = lambda x, y: 1 - chi2.cdf(x, y)
+except ImportError:
+    from .utils import chi_high
 
 try:
     from ..treeview import TreeStyle

--- a/ete3/evol/evoltree.py
+++ b/ete3/evol/evoltree.py
@@ -74,6 +74,7 @@ Yang, Z. 2007.
 '''
 
 import os
+import sys
 from warnings import warn
 
 from .. import PhyloNode, SeqGroup
@@ -243,6 +244,7 @@ class EvolNode(PhyloNode):
             raise Exception(('ERROR: {} not installed, ' +
                              'or wrong path to binary\n').format(bin))
         run, err = proc.communicate(b'\n') # send \n via stdin in case codeml/slr asks something (note on py3, stdin needs bytes)
+        run = run.decode(sys.stdout.encoding)
 
         if err is not None:
             warn("ERROR: codeml not found!!!\n" +
@@ -406,7 +408,7 @@ class EvolNode(PhyloNode):
                 node.add_feature('mark', ' '+marks[node_ids.index(node.node_id)])
             elif not 'mark' in node.features:
                 node.add_feature('mark', '')
-                
+
 
     def link_to_evol_model(self, path, model):
         '''
@@ -426,8 +428,8 @@ class EvolNode(PhyloNode):
         # new entry in _models dict
         while model.name in self._models:
             model.name = model.name.split('__')[0] + str(
-                (int(model.name.split('__')[1])
-                 +1)  if '__' in model.name else 0)
+                (int(model.name.split('__')[1]) + 1)
+                if '__' in model.name else 0)
         self._models[model.name] = model
         if not os.path.isfile(path):
             warn("ERROR: not a file: " + path)
@@ -557,4 +559,3 @@ class EvolNode(PhyloNode):
 
 # cosmetic alias
 EvolTree = EvolNode
-

--- a/ete3/tools/ete_build_lib/apps.py
+++ b/ete3/tools/ete_build_lib/apps.py
@@ -174,7 +174,7 @@ def test_apps(apps):
     if errors:
         print(colorify('\nWARNING: %d external tools seem to be missing or unfunctional' %errors, "yellow"), file=sys.stderr)
         print(colorify('Install using conda (recomended):', "lgreen"), file=sys.stderr)
-        print(colorify(' conda install -c etetoolkit ete3_external_tools', "white"), file=sys.stderr)
+        print(colorify(' conda install -c etetoolkit ete3_external_apps', "white"), file=sys.stderr)
         print(colorify('or manually compile by running:', "lgreen"), file=sys.stderr)
         print(colorify(' ete3 upgrade-external-tools', "white"), file=sys.stderr)
         print()

--- a/ete3/tools/ete_build_lib/seqio.py
+++ b/ete3/tools/ete_build_lib/seqio.py
@@ -79,10 +79,10 @@ def load_sequences(args, seqtype, target_seqs, target_species, cached_seqs):
     start_time = time.time()
     dupnames = defaultdict(int)
     for c1, (raw_seqname, seq) in enumerate(iter_fasta_seqs(seqfile)):
-        if c1 and c1 % 10000 == 0:
-            if loaded_seqs:
-                estimated_time = ((len(target_seqs)-len(loaded_seqs)) * (time.time()-start_time)) / float(c1)
-                percent = (len(loaded_seqs)/float(len(target_seqs))) * 100.0
+        if c1 % 10000 == 0 and c1:
+            if loaded_seqs and target_seqs:  # only works when workflow is supermatrix
+                estimated_time = ((len(target_seqs) - len(loaded_seqs)) * (time.time() - start_time)) / float(c1)
+                percent = (len(loaded_seqs) / float(len(target_seqs))) * 100.0
             else:
                 percent = 0
                 estimated_time = -1            

--- a/ete3/tools/ete_evol.py
+++ b/ete3/tools/ete_evol.py
@@ -452,8 +452,8 @@ def name_model(tree, base_name):
     transform the name string into summary of its name and a digestion of the
     full name
     """
-    return base_name[:12] + '~' + md5(tree.get_topology_id(attr="name") +
-                                      base_name).hexdigest()
+    return base_name[:12] + '~' + md5((tree.get_topology_id(attr="name") +
+                                       base_name).encode('utf8')).hexdigest()
 
 
 def local_run_model(tree, model_name, binary, ctrl_string='', **kwargs):

--- a/ete3/treeview/faces.py
+++ b/ete3/treeview/faces.py
@@ -1512,7 +1512,7 @@ class _BarChartItem(QGraphicsRectItem):
             if self.labels:
                 p.save()
                 p.translate(x1, plot_height+2)
-                p.setRotation(90)
+                p.rotate(90)
                 p.drawText(0, -x_alpha, label_height, x_alpha, Qt.AlignVCenter, str(self.labels[pos]))
                 #p.drawRect(0, -x_alpha, label_height, x_alpha)
                 p.restore()

--- a/ete3/treeview/faces.py
+++ b/ete3/treeview/faces.py
@@ -1512,7 +1512,7 @@ class _BarChartItem(QGraphicsRectItem):
             if self.labels:
                 p.save()
                 p.translate(x1, plot_height+2)
-                p.rotate(90)
+                p.setRotation(90)
                 p.drawText(0, -x_alpha, label_height, x_alpha, Qt.AlignVCenter, str(self.labels[pos]))
                 #p.drawRect(0, -x_alpha, label_height, x_alpha)
                 p.restore()
@@ -2072,7 +2072,7 @@ class SequencePlotFace(StaticItemFace):
             text = QGraphicsSimpleTextItem(self.ylabel)
             text.setFont(QFont("Arial", self.fsize-1))
             text.setParentItem(self.item)
-            text.rotate(-90)
+            text.setRotation(-90)
             tw = text.boundingRect().width()
             th = text.boundingRect().height()
             # Center text according to masterItem size

--- a/ete3/treeview/faces.py
+++ b/ete3/treeview/faces.py
@@ -1335,7 +1335,7 @@ class BarChartFace(Face):
     :param 200 width: width of the bar chart.
     :param 100 height: height of the bar chart
     :param None colors: a list of colors, one per bar value
-    :param None label: a list of labels, one per bar
+    :param None labels: a list of labels, one per bar
     :param 0 min_value: min value to set the scale of the chart.
     :param None max_value: max value to set the scale of the chart.
 


### PR DESCRIPTION
# Fixes
 - Python3 compatibility issues fixed, in ete evol tool and test_ete_evol (string encoding issues).
 - PyQt5 compatibility
 - chi2 test was missing variables when high df (also ete evol now uses chi2 from scipy when scipy is installed)

# Performance
 - Tree.prune is now much faster when list of input nodes are TreeObjects

# Doc
 - removed reference to _nid in Tree.sort_descendants function
 - fixed typo in warning to install external apps