### PR TITLE
midpoint root between the two most distant leaves

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1135,7 +1135,7 @@ class TreeNode(object):
         # Gets the farthest node to the current root
         root = self.get_tree_root()
         nA, r2A_dist = root.get_farthest_leaf()
-        nB, A2B_dist = nA.get_farthest_node()
+        nB, A2B_dist = nA.get_farthest_leaf()
 
         outgroup = nA
         middist  = A2B_dist / 2.0


### PR DESCRIPTION
Midpoint rooting should place the root between the two most distant leaves. As currently implemented it leads to unbalanced trees (see image below). Change is untested. :man_shrugging: 

![check](https://user-images.githubusercontent.com/7765807/53498908-98432f00-3aa7-11e9-826e-f751e1cb7ebd.png)
