### PR TITLE
update ncbiquery unittest corresponding NCBI #443

### DIFF
--- a/ete3/test/test_ncbiquery.py
+++ b/ete3/test/test_ncbiquery.py
@@ -56,12 +56,13 @@ class Test_ncbiquery(unittest.TestCase):
     self.assertEqual(set(name2id['Bacteria']), set([2]))
 
     out = ncbi.get_descendant_taxa("9605", intermediate_nodes=True)
-    #Out[9]: [1425170, 741158, 63221, 9606]
-    self.assertEqual(set(out), set([1425170, 741158, 63221, 9606]))
+    #Out[9]: [9606, 63221, 741158, 2665952, 2665953, 1425170]
+    # New Taxonomies of Homo in NCBI, {2665952: 'environmental samples', 2665953: 'Homo sapiens environmental sample'}
+    self.assertEqual(set(out), set([9606, 63221, 741158, 2665952, 2665953, 1425170]))
     
     out = ncbi.get_descendant_taxa("9605", intermediate_nodes=False)
-    #Out[10]: [1425170, 741158, 63221]
-    self.assertEqual(set(out), set([1425170, 741158, 63221]))
+    #Out[10]: [63221, 741158, 2665953, 1425170]
+    self.assertEqual(set(out), set([63221, 741158, 2665953, 1425170]))
     
     out = ncbi.get_descendant_taxa("9605", intermediate_nodes=False, rank_limit="species")
     #Out[11]: [9606, 1425170]


### PR DESCRIPTION
update unittest of test_ncbiquery in regard to new NCBI Taxonomies of Homo

ref:
https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9605