### PR TITLE
Handling outdated taxdump file etetoolkit#416

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -749,6 +749,9 @@ def update_db(dbfile, targz_file=None):
             local_md5 = md5(open("taxdump.tar.gz", "rb").read()).hexdigest()
             if local_md5 != md5_check:
                 do_download = True
+                print('Updating taxdump.tar.gz from NCBI FTP site (via HTTP)...', file=sys.stderr)
+                urlretrieve("http://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz", targz_file)
+                print('Done. Parsing...', file=sys.stderr)
             else:
                 print('Local taxdump.tar.gz seems up-to-date', file=sys.stderr)
         else:


### PR DESCRIPTION
if taxdump.tar.gz is not up-to-date, download the latest version and replace the outdated one