### PR TITLE
returns itself if same node is provided as only argument of get_common_ancestor 

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -884,10 +884,19 @@ class TreeNode(object):
         # Convert node names into node instances
         target_nodes = _translate_nodes(self, *target_nodes)
 
-        # If only one node is provided, use self as the second target
-        if type(target_nodes) != list:
-            target_nodes = [target_nodes, self]
 
+        if type(target_nodes) != list:
+            # If only one node is provided and is the same as the seed node,
+            # return itself
+            if target_nodes is self:
+                if get_path:
+                    return self, {}
+                else:
+                    return self
+            else:
+                #Otherwise find the common ancestor of current seed node and
+                #the target_node provided
+                target_nodes = [target_nodes, self]
 
         n2path = {}
         reference = []
@@ -2442,7 +2451,7 @@ class TreeNode(object):
                 else:
                     output[i].append(leaf_distances[n][m])
         return output, allleaves
-                     
+
     def add_face(self, face, column, position="branch-right"):
         """
         .. versionadded: 2.1
@@ -2485,14 +2494,14 @@ class TreeNode(object):
 
     @staticmethod
     def from_parent_child_table(parent_child_table):
-        """Converts a parent-child table into an ETE Tree instance. 
-        
+        """Converts a parent-child table into an ETE Tree instance.
+
         :argument parent_child_table: a list of tuples containing parent-child
            relationships. For example: [("A", "B", 0.1), ("A", "C", 0.2), ("C",
            "D", 1), ("C", "E", 1.5)]. Where each tuple represents: [parent, child,
            child-parent-dist]
-        
-        :returns: A new Tree instance 
+
+        :returns: A new Tree instance
 
         :example:
 
@@ -2527,20 +2536,20 @@ class TreeNode(object):
 
     @staticmethod
     def from_skbio(skbio_tree, map_attributes=None):
-        """Converts a scikit-bio TreeNode object into ETE Tree object. 
-        
-        :argument skbio_tree: a scikit bio TreeNode instance 
+        """Converts a scikit-bio TreeNode object into ETE Tree object.
+
+        :argument skbio_tree: a scikit bio TreeNode instance
 
         :argument None map_attributes: A list of attribute nanes in the
            scikit-bio tree that should be mapped into the ETE tree
            instance. (name, id and branch length are always mapped)
 
-        :returns: A new Tree instance 
+        :returns: A new Tree instance
 
         :example:
 
         >>> tree = Tree.from_skibio(skbioTree, map_attributes=["value"])
-        
+
         """
         from skbio import TreeNode as skbioTreeNode
 
@@ -2601,8 +2610,3 @@ def _translate_nodes(root, *nodes):
 # Alias
 #: .. currentmodule:: ete3
 Tree = TreeNode
-
-
-
-
-

--- a/ete3/parser/newick.py
+++ b/ete3/parser/newick.py
@@ -225,19 +225,19 @@ def read_newick(newick, root_node=None, format=0, quoted_names=False):
     You can also take advantage from this behaviour to concatenate
     several tree structures.
     """
-   
+
     if root_node is None:
         from ..coretype.tree import TreeNode
         root_node = TreeNode()
 
     if isinstance(newick, six.string_types):
 
-        # try to determine whether the file exists.  
+        # try to determine whether the file exists.
         # For very large trees, if newick contains the content of the tree, rather than a file name,
-        # this may fail, at least on Windows, because the os fails to stat the file content, deeming it 
+        # this may fail, at least on Windows, because the os fails to stat the file content, deeming it
         # too long for testing with os.path.exists.  This raises a ValueError with description
         # "stat: path too long for Windows".  This is described in issue #258
-        try: 
+        try:
             file_exists = os.path.exists(newick)
         except ValueError:      # failed to stat
             file_exists = False
@@ -246,9 +246,11 @@ def read_newick(newick, root_node=None, format=0, quoted_names=False):
         if file_exists:
             if newick.endswith('.gz'):
                 import gzip
-                nw = gzip.open(newick).read()
+                with gzip.open(newick) as INPUT:
+                    nw = INPUT.read()
             else:
-                nw = open(newick, 'r').read()
+                with open(newick) as INPUT:
+                    nw = INPUT.read()
         else:
             nw = newick
 
@@ -269,7 +271,7 @@ def read_newick(newick, root_node=None, format=0, quoted_names=False):
 def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
     """ Reads a newick string in the New Hampshire format. """
 
-    if quoted_names: 
+    if quoted_names:
         # Quoted text is mapped to references
         quoted_map = {}
         unquoted_nw = ''
@@ -416,7 +418,7 @@ def _read_node_data(subnw, current_node, node_type, matcher, formatcode):
         node = current_node
 
     subnw = subnw.strip()
-    
+
     if not subnw and node_type == 'leaf' and formatcode != 100:
         raise NewickError('Empty leaf node found')
     elif not subnw:
@@ -507,5 +509,3 @@ def _get_features_string(self, features=None):
         string = "[&&NHX:"+string+"]"
 
     return string
-
-

--- a/ete3/test/test_tree.py
+++ b/ete3/test/test_tree.py
@@ -56,7 +56,9 @@ class Test_Coretype_Tree(unittest.TestCase):
         """ Tests newick support """
         # Read and write newick tree from file (and support for NHX
         # format): newick parser
-        open("/tmp/etetemptree.nw","w").write(nw_full)
+        with open("/tmp/etetemptree.nw","w") as OUT:
+            OUT.write(nw_full)
+
         t = Tree("/tmp/etetemptree.nw")
         t.write(outfile='/tmp/etewritetest.nw')
         self.assertEqual(nw_full, t.write(features=["flag","mood"]))
@@ -494,10 +496,10 @@ class Test_Coretype_Tree(unittest.TestCase):
         common = A.get_common_ancestor(C)
         self.assertEqual("root", common.get_tree_root().tag)
 
-        self.assert_(common.get_tree_root().is_root())
-        self.assert_(not A.is_root())
-        self.assert_(A.is_leaf())
-        self.assert_(not A.get_tree_root().is_leaf())
+        self.assertTrue(common.get_tree_root().is_root())
+        self.assertTrue(not A.is_root())
+        self.assertTrue(A.is_leaf())
+        self.assertTrue(not A.get_tree_root().is_leaf())
         self.assertRaises(TreeError, A.get_common_ancestor, Tree())
 
         # Test multiple target nodes and get_path argument
@@ -508,13 +510,14 @@ class Test_Coretype_Tree(unittest.TestCase):
         self.assertEqual(common, N2)
         self.assertEqual(path.keys(), expected_path.keys())
         for k in path.keys():
-            self.assertEqual(list(sorted(path[k])), list(sorted(expected_path[k])))
+            self.assertEqual(list(sorted(path[k], key=lambda x: x.name)),
+                             list(sorted(expected_path[k], key=lambda x: x.name)))
 
         # Test common ancestor function using self as single argument (issue #398)
         common = A.get_common_ancestor(A)
-        self.assert_(common, A)
+        self.assertEqual(common, A)
         common = C.get_common_ancestor("C")
-        self.assert_(common, C)
+        self.assertEqual(common, C)
         common, path = C.get_common_ancestor("C", get_path=True)
         self.assertEqual(common, C)
         self.assertDictEqual(path, {})
@@ -532,10 +535,10 @@ class Test_Coretype_Tree(unittest.TestCase):
         # Tree magic python features
         t = Tree(nw_dflt)
         self.assertEqual(len(t), 20)
-        self.assert_("Ddi0002240" in t)
-        self.assert_(t.children[0] in t)
+        self.assertTrue("Ddi0002240" in t)
+        self.assertTrue(t.children[0] in t)
         for a in t:
-            self.assert_(a.name)
+            self.assertTrue(a.name)
 
         # Populate
         t = Tree(nw_full)
@@ -554,13 +557,13 @@ class Test_Coretype_Tree(unittest.TestCase):
 
         # Check gettters and itters return the same
         t = Tree(nw2_full)
-        self.assert_(t.get_leaf_names(), [name for name in  t.iter_leaf_names()])
-        self.assert_(t.get_leaves(), [name for name in  t.iter_leaves()])
-        self.assert_(t.get_descendants(), [n for n in  t.iter_descendants()])
+        self.assertEqual(t.get_leaf_names(), [name for name in  t.iter_leaf_names()])
+        self.assertEqual(t.get_leaves(), [name for name in  t.iter_leaves()])
+        self.assertEqual(t.get_descendants(), [n for n in  t.iter_descendants()])
 
         self.assertEqual(set([n for n in t.traverse("preorder")]), \
                              set([n for n in t.traverse("postorder")]))
-        self.assert_(t in set([n for n in t.traverse("preorder")]))
+        self.assertTrue(t in set([n for n in t.traverse("preorder")]))
 
         # Check order or visiting nodes
 


### PR DESCRIPTION
should fix #398 