### PR TITLE
option to choose your local apps_bin path

### DIFF
--- a/ete3/tools/ete.py
+++ b/ete3/tools/ete.py
@@ -141,11 +141,12 @@ def _main(arguments):
             #builtin_apps_path = None
             #ete3_path = which("ete3")
 
-            # is it a good place to make judgement?
+            
             #if ete3_path:
-            #    builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin") #Ziqi
+            #    builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin") 
             #    builtin_apps_path = os.path.split(ete3_path)[0]
-            ete_build._main(arguments)
+
+            ete_build._main(arguments) # pass arguments to ete_build including flag of apps_bin, so as to determine apps_path there
             return
 
     # CREATE REUSABLE PARSER OPTIONS

--- a/ete3/tools/ete.py
+++ b/ete3/tools/ete.py
@@ -138,15 +138,14 @@ def _main(arguments):
         elif subcommand == "build": 
             from . import ete_build
             del arguments[1]
+            #builtin_apps_path = None
+            #ete3_path = which("ete3")
 
-            builtin_apps_path = None
-            ete3_path = which("ete3")
-
-            if ete3_path:
-                builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin") #Ziqi
-                #builtin_apps_path = os.path.split(ete3_path)[0]
-            ete_build._main(arguments, builtin_apps_path)
-            
+            # is it a good place to make judgement?
+            #if ete3_path:
+            #    builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin") #Ziqi
+            #    builtin_apps_path = os.path.split(ete3_path)[0]
+            ete_build._main(arguments)
             return
 
     # CREATE REUSABLE PARSER OPTIONS

--- a/ete3/tools/ete_build.py
+++ b/ete3/tools/ete_build.py
@@ -706,7 +706,6 @@ def _main(arguments):
                              type=is_file, default=BASEPATH+'/ete_build.cfg',
                              help="Base configuration file.")
 
-    # Ziqi check this
     input_group.add_argument("-L", "--tools-dir", dest="tools_dir",
                              type=str,
                              #required=True, #Ziqi
@@ -980,6 +979,7 @@ def _main(arguments):
                 else:
                     raise ValueError("The provided custom path for external tools is not a valid directory")
         else:
+            # default path is ete3_apps/bin
             print(colorify('\nWARNING: path of external tools is not provided, now loading TOOLCHAIN\n', "yellow"), file=sys.stderr)
             builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin")
             

--- a/ete3/tools/ete_build.py
+++ b/ete3/tools/ete_build.py
@@ -979,15 +979,28 @@ def _main(arguments):
                 else:
                     raise ValueError("The provided custom path for external tools is not a valid directory")
         else:
-            print(colorify('\nWARNING: path of external tools is not provided, now loading TOOLCHAIN', "yellow"), file=sys.stderr)
+            print(colorify('\nWARNING: path of external tools is not provided, now loading TOOLCHAIN\n', "yellow"), file=sys.stderr)
             builtin_apps_path = os.path.join(os.path.split(ete3_path)[0], "ete3_apps/bin")
+            
+            
             if not os.path.exists(builtin_apps_path):
-                raise ValueError("you path please")
+                print(colorify('\nWARNING: external applications directory are not found at %s' %builtin_apps_path, "yellow"), file=sys.stderr)
+                print(colorify('Use "ete build install_tools" to install or upgrade tools', "orange"), file=sys.stderr)
+                print(colorify('\nWARNING: external applications not found', "yellow"), file=sys.stderr)
+                print(colorify('Install using conda (recomended):', "lgreen"), file=sys.stderr)
+                print(colorify(' conda install -c etetoolkit ete_toolchain', "white"), file=sys.stderr)
+                print(colorify('or manually compile from:', "lgreen"), file=sys.stderr)
+                print(colorify(' https://github.com/etetoolkit/ete_toolchain', "white"), file=sys.stderr)
+                print(colorify('or manually compile from:', "lgreen"), file=sys.stderr)
+                print(colorify(' https://anaconda.org/bioconda', "white"), file=sys.stderr)
+                raise ValueError(colorify("Please select binary path of your external apps by adding -L [custom path]| LOCAL| TOOLCHAIN.", "yellow"))
             else:
                 APPSPATH = builtin_apps_path
             
     else:
-            raise ValueError("ETE's toolchain directory is missing")
+        #print(colorify('\nWARNING: external applications directory are not found at %s' % ete3_path, "yellow"), file=sys.stderr)
+        #print(colorify('Use "ete build install_tools" to install or upgrade tools', "orange"), file=sys.stderr)
+        raise ValueError("ETE's toolchain directory is missing!\n Please select binary path of your external apps by -L [custom path]| LOCAL| TOOLCHAIN.")
 
     #######################################################
     if len(arguments) == 1:

--- a/ete3/tools/ete_build.py
+++ b/ete3/tools/ete_build.py
@@ -960,6 +960,7 @@ def _main(arguments):
 
     args = parser.parse_args(arguments)
 
+    # start to load apps_path depending on flags, therefore need to load args before load the path
     ete3_path = shutil.which("ete3")
     if ete3_path:
         if args.tools_dir:    


### PR DESCRIPTION
The origin experimental --tools-dir is functional when "ete3 build -w .....", but it doesn't work to subcommand such as "check".  Changes that I made:

1) read the arguments before load the apps_bin;
2) muted the "require=True" in workflow argument, ortherwise it goes error

example:
`ete3 build check -L [custom path], TOOLCHAIN, LOCAL`

I wonder if there is more elegant way?