### PR TITLE
Fix return value of get_descendant_taxa

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -371,7 +371,7 @@ class NCBITaxa(object):
             elif intermediate_nodes:
                 return list(map(int, [n.name for n in tree.get_descendants()]))
             else:
-                return map(int, [n.name for n in tree])
+                return list(map(int, [n.name for n in tree]))
                 
         elif intermediate_nodes:
             return [tid for tid, count in six.iteritems(descendants)]


### PR DESCRIPTION
get_descendant_taxa returns a generator from the `map` function if `collapse_subspecies = True`.  This quick-fix returns a list instead which is done throughout this method and the parent class.

This fixes problems with the documentation and with the issue mentioned in #308.