### PR TITLE
Ignore duplicate synonyms for Taxa DB insert

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -823,7 +823,7 @@ def upload_data(dbfile):
             print('\rInserting synonyms:     % 6d' %i, end=' ', file=sys.stderr)
             sys.stderr.flush()
         taxid, spname = line.strip('\n').split('\t')
-        db.execute("INSERT INTO synonym (taxid, spname) VALUES (?, ?);", (taxid, spname))
+        db.execute("INSERT OR IGNORE INTO synonym (taxid, spname) VALUES (?, ?);", (taxid, spname))
     print()
     db.commit()
     for i, line in enumerate(open("merged.tab")):


### PR DESCRIPTION
There are synonyms that are identical but surrounded by quotes.  This triggers a unique constraint exception, i.e.:

```
Inserting synonyms:      120000 ---------------------------------------------------------------------------
IntegrityError                            Traceback (most recent call last)
...
IntegrityError: UNIQUE constraint failed: synonym.spname, synonym.taxid
```

Instead of adding more logic to strip the quotes, we could just ignore when the UNIQUE constraint is triggered on database insert.

For example, the synonyms set will contain:
```
[('92835', '"Aureobacterium ketoreductum"'),
 ('92835', 'Aureobacterium ketoreductum'),
 ('92835', 'Aureibacterium ketoreductum')]
```
The quotes will only get stripped later when interpreted as a SQL string.