### PR TITLE
Fixed string encoding for WebPlugin webapp.py for Python3

### DIFF
--- a/ete3/webplugin/webapp.py
+++ b/ete3/webplugin/webapp.py
@@ -314,7 +314,7 @@ class WebTreeApplication(object):
                     html += """<li><a  href='javascript:void(0);' onClick='hide_popup(); run_action("%s", "%s", "%s");'> %s </a></li> """ %\
                         (treeid, nodeid, i, aname)
             html += '</ul>'
-            return html
+            return [html.encode('utf-8')]
 
         elif method == "action":
             if not self._load_tree(treeid):
@@ -322,16 +322,16 @@ class WebTreeApplication(object):
 
             if aindex is None:
                 # just refresh tree
-                return self._get_tree_img(treeid=treeid)
+                return [self._get_tree_img(treeid=treeid).encode('utf-8')]
             else:
                 aname, target, handler, checker, html_generator = self.actions[int(aindex)]
 
             if target in set(["node", "face", "layout"]):
-                return self._get_tree_img(treeid=treeid, pre_drawing_action=[target, handler, [nodeid]])
+                return [self._get_tree_img(treeid=treeid, pre_drawing_action=[target, handler, [nodeid]]).encode('utf-8')]
             elif target in set(["search"]):
-                return self._get_tree_img(treeid=treeid, pre_drawing_action=[target, handler, [search_term]])
+                return [self._get_tree_img(treeid=treeid, pre_drawing_action=[target, handler, [search_term]]).encode('utf-8')]
             elif target in set(["refresh"]):
-                return self._get_tree_img(treeid=treeid)
+                return [self._get_tree_img(treeid=treeid).encode('utf-8')]
             return "Bad guy"
 
         elif self._external_app_handler:


### PR DESCRIPTION
Background: Some of the intended functionality of ete3's webplugin app wasn't working properly (the WebTreeAplication's __call__ function)

After some digging, I found out that the issue had to do with string encoding (as the native string is bytes for python2 and text for python3: [https://portingguide.readthedocs.io/en/latest/strings.html](https://portingguide.readthedocs.io/en/latest/strings.html)) provided WSGI applications are required to yield bytes objects: [Str in Python2 and bytes in Python3 ](https://github.com/fgallaire/wsgiserver/issues/2#issuecomment-243319409)

My code solutions were rather simple but I tried to fix (most of) the encoding errors I was able to pinpoint through my testing.