### PR TITLE
Allow custom location for taxa.sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 *~
 #*#
 doc/_build/
+sdoc/_build/
 dist/
 *.egg-info
 

--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -107,7 +107,7 @@ class NCBITaxa(object):
         if taxdump_file:
             self.update_taxonomy_database(taxdump_file)
 
-        if dbfile is None and not os.path.exists(self.dbfile):
+        if dbfile != DEFAULT_TAXADB and not os.path.exists(self.dbfile):
             print('NCBI database not present yet (first time used?)', file=sys.stderr)
             self.update_taxonomy_database(taxdump_file)
 

--- a/sdoc/reference/reference_ncbi.rst
+++ b/sdoc/reference/reference_ncbi.rst
@@ -1,10 +1,10 @@
-.. module:: ete2.ncbi_taxonomy
+.. module:: ete3.ncbi_taxonomy
 
 ====================
 NCBITaxa class
 ====================
 
-.. autoclass:: ete2.NCBITaxa
+.. autoclass:: ete3.NCBITaxa
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
This small change allows the user to define the location of the `taxa.sqlite`
Right now, `taxa.sqlite` must always be in `$HOME/.etetoolkit` which is sometimes problematics when using etetools in containers (Docker, Singularity) and HPC/Cloud that don't always have a `$HOME` directory

**Before:**
```python
>>> import os
>>> os.listdir("/Users/borry/Desktop/etetoolkit")
[]
>>> from ete3 import NCBITaxa
>>> ncbi = NCBITaxa(dbfile="/Users/borry/Desktop/etetoolkit/taxa.sqlite")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/borry/Documents/GitHub/ete/ete3/ncbi_taxonomy/ncbiquery.py", line 116, in __init__
    raise ValueError("Cannot open taxonomy database: %s" % self.dbfile)
ValueError: Cannot open taxonomy database: /Users/borry/Desktop/etetoolkit/taxa.sqlite
```

**After:**
```python
>>> import os
>>> os.listdir("/Users/borry/Desktop/etetoolkit")
[]
>>> from ete3 import NCBITaxa
>>> ncbi = NCBITaxa(dbfile="/Users/borry/Desktop/etetoolkit/taxa.sqlite")
NCBI database not present yet (first time used?)
Local taxdump.tar.gz seems up-to-date
Loading node names...
2308070 names loaded.
241388 synonyms loaded.
Loading nodes...
2308070 nodes loaded.
Linking nodes...
Tree is loaded.
pdating database: /Users/borry/Desktop/etetoolkit/taxa.sqlite ...
 2308000 generating entries...
Uploading to /Users/borry/Desktop/etetoolkit/taxa.sqlite

Inserting synonyms:      240000
Inserting taxid merges:  60000
Inserting taxids:       2305000
>>> ncbi.get_taxid_translator([9606, 9443])
{9443: 'Primates', 9606: 'Homo sapiens'}
>>> os.listdir("/Users/borry/Desktop/etetoolkit")
['taxa.sqlite.traverse.pkl', 'taxa.sqlite']
```