### PR TITLE
Summarize the names of collapsed nodes respecting their original order.

### DIFF
--- a/ete4/smartview/ete/draw.pyx
+++ b/ete4/smartview/ete/draw.pyx
@@ -3,7 +3,7 @@ Classes and functions for drawing a tree.
 """
 
 from math import sin, cos, pi, sqrt, atan2
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 import random
 
 from ete4.smartview.tree import walk
@@ -617,9 +617,7 @@ def get_drawers():
 
 def summary(nodes):
     "Return a list of names summarizing the given list of nodes"
-    return list(set(first_name(node) for node in nodes))
-    # NOTE: This doesn't preserve the order, but it is *much* faster than
-    #   iterating in a list and saving only if they are not already there.
+    return list(OrderedDict((first_name(node), None) for node in nodes).keys())
 
 
 def first_name(tree):


### PR DESCRIPTION
This change makes the names of the collapsed nodes appear in order
in their summary string representation.

Before, we used to put them together with a set, so the order was
not preserved. Using a list instead was no good, since for big
trees the speed difference to remove duplicates was tremendous
(~100x slower).

Ideally, we would have used something similar to an OrderedSet in
python, but there is no such thing in the standard library. Instead
we now use an OrderedDict with keys the names of the nodes we want
and values set to None.

They work like a charm :)