### PR TITLE
Fix docstring typo in TreeNode.robinson_foulds

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1658,7 +1658,7 @@ class TreeNode(object):
         :param name attr_t2: Compare trees using a custom node
                               attribute as a node name in target tree.
 
-        :param False attr_t2: If True, consider trees as unrooted.
+        :param False unrooted_trees: If True, consider trees as unrooted.
 
         :param False expand_polytomies: If True, all polytomies in the reference
            and target tree will be expanded into all possible binary


### PR DESCRIPTION
change duplicate "attr_t2" to "unrooted_trees," which is consistent with the explanation for this parameter in the docstring, "If True, consider trees as unrooted"