### PR TITLE
allow any callable as argument to TreeStyle.set_layout_fn

### DIFF
--- a/ete3/treeview/main.py
+++ b/ete3/treeview/main.py
@@ -407,7 +407,7 @@ class TreeStyle(object):
 
         for ly in layout:
             # Validates layout function
-            if (type(ly) == types.FunctionType or type(ly) == types.MethodType or ly is None):
+            if callable(ly) is True or ly is None:
                 self._layout_handler.append(ly)
             else:
                 from . import layouts


### PR DESCRIPTION
This PR allows any callable object to be set as the layout function of a `TreeStyle` object.

Currently, only objects whose type match `types.FunctionType` or `types.MethodType` are allowed. This behavior excludes otherwise valid Python callables, e.g. partial functions created with `functools.partial`, or any used-defined class that implements `__call__`, irrespective of whether the actual call would succeed or not.

The PR fixes this by using the `callable` built-in function for checking the layout function's type.