### PR TITLE
Resolve #568. Tight adjustment of faces in circular mode

### DIFF
--- a/ete3/treeview/drawer.py
+++ b/ete3/treeview/drawer.py
@@ -66,7 +66,7 @@ def init_scene(t, layout, ts):
     if not _QApp:
         _QApp = QApplication(["ETE"])
 
-    scene  = _TreeScene()
+    scene = _TreeScene()
 	#ts._scale = None
     return scene, ts
 

--- a/ete3/treeview/main.py
+++ b/ete3/treeview/main.py
@@ -323,6 +323,9 @@ class TreeStyle(object):
     :param True complete_branch_lines_when_necessary: True or False.
       Draws an extra line (dotted by default) to complete branch lengths when the space to cover is larger than the branch itself.
 
+    :param False pack_leaves: True or False.
+      For circular layouts, pull leaf nodes closer to center while avoiding collisions.
+
     :param 2 extra_branch_line_type:  0=solid, 1=dashed, 2=dotted
 
     :param "gray" extra_branch_line_color: RGB code or name in
@@ -487,6 +490,7 @@ class TreeStyle(object):
         # branch length, branch line can be completed. Also, when
         # circular trees are drawn,
         self.complete_branch_lines_when_necessary = True
+        self.pack_leaves = False
         self.extra_branch_line_type = 2 # 0 solid, 1 dashed, 2 dotted
         self.extra_branch_line_color = "gray"
 

--- a/ete3/treeview/qt4_circular_render.py
+++ b/ete3/treeview/qt4_circular_render.py
@@ -39,6 +39,7 @@
 from __future__ import absolute_import
 import math
 import colorsys
+import itertools
 
 from .qt import *
 from .main import _leaf, tracktime
@@ -192,7 +193,7 @@ def get_min_radius(w, h, angle, xoffset):
     return r, off
 
 def render_circular(root_node, n2i, rot_step):
-    max_r = 0.0
+    max_r = max_x = min_x = max_y = min_y = 0.0
     for node in root_node.traverse('preorder', is_leaf_fn=_leaf):
         item = n2i[node]
         w = sum(item.widths[1:5])
@@ -253,9 +254,19 @@ def render_circular(root_node, n2i, rot_step):
                 for i in item.movable_items:
                     i.moveBy(xoffset, 0)
 
+        for qt_item in itertools.chain(item.static_items, item.movable_items):
+            b_rect = qt_item.sceneBoundingRect()
+            if b_rect.top() < min_y:
+                min_y = b_rect.top()
+            if b_rect.bottom() > max_y:
+                max_y = b_rect.bottom()
+            if b_rect.left() < min_x:
+                min_x = b_rect.left()
+            if b_rect.right() > max_x:
+                max_x = b_rect.right()
 
     n2i[root_node].max_r = max_r
-    return max_r
+    return max_r, min_y, max_y, min_x, max_x
 
 def init_circular_leaf_item(node, n2i, n2f, last_rotation, rot_step):
     item = n2i[node]

--- a/ete3/treeview/qt4_render.py
+++ b/ete3/treeview/qt4_render.py
@@ -304,8 +304,14 @@ def render(root_node, img, hide_root=False):
     mainRect = parent.rect()
 
     if mode == "c":
-        tree_radius = crender.render_circular(root_node, n2i, rot_step)
-        mainRect.adjust(-tree_radius, -tree_radius, tree_radius, tree_radius)
+        tree_radius, min_y, max_y, min_x, max_x = crender.render_circular(root_node, n2i, rot_step)
+        # If semicircle and cropping removes at least 25% of mainRect's area, crop
+        full_circle_area = (tree_radius * 2) ** 2
+        cropped_area = (max_x - min_x) * (max_y - min_y)
+        if arc_span < 359 and (cropped_area / full_circle_area) < 0.75:
+            mainRect.adjust(min_x, min_y, max_x, max_y)
+        else:
+            mainRect.adjust(-tree_radius, -tree_radius, tree_radius, tree_radius)
     else:
         iwidth = n2i[root_node].fullRegion.width()
         iheight = n2i[root_node].fullRegion.height()

--- a/ete3/treeview/qt4_render.py
+++ b/ete3/treeview/qt4_render.py
@@ -39,6 +39,7 @@
 import math
 import re
 import six
+import itertools
 
 from .qt import *
 from . import qt4_circular_render as crender
@@ -304,7 +305,7 @@ def render(root_node, img, hide_root=False):
     mainRect = parent.rect()
 
     if mode == "c":
-        tree_radius, min_y, max_y, min_x, max_x = crender.render_circular(root_node, n2i, rot_step)
+        tree_radius, min_y, max_y, min_x, max_x = crender.render_circular(root_node, n2i, rot_step, img.pack_leaves)
         # If semicircle and cropping removes at least 25% of mainRect's area, crop
         full_circle_area = (tree_radius * 2) ** 2
         cropped_area = (max_x - min_x) * (max_y - min_y)
@@ -414,29 +415,6 @@ def add_title(img, mainRect, parent):
         title.setParentItem(parent)
         mainRect.adjust(0, -lg_h, dw, 0)
         title.setPos(mainRect.topLeft())
-
-def add_legend(img, mainRect, parent):
-    if img.legend:
-        legend = _FaceGroupItem(img.legend, None)
-        legend.setup_grid()
-        legend.render()
-        lg_w, lg_h = legend.get_size()
-        dw = max(0, lg_w-mainRect.width())
-        legend.setParentItem(parent)
-        if img.legend_position == 1:
-            mainRect.adjust(0, -lg_h, dw, 0)
-            legend.setPos(mainRect.topLeft())
-        elif img.legend_position == 2:
-            mainRect.adjust(0, -lg_h, dw, 0)
-            pos = mainRect.topRight()
-            legend.setPos(pos.x()-lg_w, pos.y())
-        elif img.legend_position == 3:
-            legend.setPos(mainRect.bottomLeft())
-            mainRect.adjust(0, 0, dw, lg_h)
-        elif img.legend_position == 4:
-            pos = mainRect.bottomRight()
-            legend.setPos(pos.x()-lg_w, pos.y())
-            mainRect.adjust(0, 0, dw, lg_h)
 
 def add_scale(img, mainRect, parent):
     if img.show_scale:
@@ -627,7 +605,6 @@ def render_node_content(node, n2i, n2f, img):
     # Node points
     ball_size = style["size"]
 
-
     vlw = style["vt_line_width"] if not _leaf(node) and len(node.children) > 1 else 0.0
 
     # face_start_x = nodeR.width() - facesR.width() - vlw
@@ -692,6 +669,7 @@ def render_node_content(node, n2i, n2f, img):
         extra_line.setPen(pen)
     else:
         extra_line = None
+        item.extra_branch_line = extra_line
 
     # Attach branch-right faces to child
     fblock_r = n2f[node]["branch-right"]


### PR DESCRIPTION
Resolves #568. 
Changes:  
1) Remove excess whitespace in semicircle layouts.
```
from ete3 import Tree, TreeStyle
t = Tree()
t.populate(30)
ts = TreeStyle()
ts.show_leaf_name = True
ts.mode = "c"
ts.arc_start = -180 # 0 degrees = 3 o'clock
ts.arc_span = 180
t.render('example.png', tree_style=ts)
```
![example](https://user-images.githubusercontent.com/8942305/135498631-38fbeaf4-2f3b-4b34-9ba4-a9ee98610f45.png)


2) Added ability to bring leaf nodes closer to center in circular layouts by reducing the length of each leaf's extra branch line as much as possible while avoiding intersecting QGraphicsItems. The 'pack_leaves' parameter in TreeStyle is used to turn this feature on. 
```
from ete3 import Tree, TreeStyle, CircleFace

t = Tree()
t.populate(15)

ts = TreeStyle()
ts.scale = 100
ts.show_leaf_name = False
ts.mode = 'c'
ts.arc_start = -45
ts.arc_span = 90
ts.force_topology = True
ts.pack_leaves = True
node_sizes = [25, 25, 150, 25, 25, 25, 25, 25, 25, 25, 25, 150, 25, 25, 25]

for i, node in enumerate(t.iter_leaves()):
    node.add_face(CircleFace(node_sizes[i], 'Red'), column=0, position='branch-right')

t.render('example.png', tree_style=ts)
```
![example](https://user-images.githubusercontent.com/8942305/135499311-2b2266e8-c4bd-4930-928a-4598c71be6fa.png)
