### PR TITLE
Props debugging phylo

### DIFF
--- a/ete4/clustering/clustertree.py
+++ b/ete4/clustering/clustertree.py
@@ -114,11 +114,11 @@ class ClusterNode(TreeNode):
         self._std_profile = None
 
         # Cluster especific features
-        self.features.add("intercluster_dist")
-        self.features.add("intracluster_dist")
-        self.features.add("silhouette")
-        self.features.add("profile")
-        self.features.add("deviation")
+        # self.features.add("intercluster_dist")
+        # self.features.add("intracluster_dist")
+        # self.features.add("silhouette")
+        # self.features.add("profile")
+        # self.features.add("deviation")
 
         # Initialize tree with array data
         if text_array:

--- a/ete4/phylo/phylotree.py
+++ b/ete4/phylo/phylotree.py
@@ -447,7 +447,8 @@ class PhyloNode(TreeNode):
 
     def get_species(self):
         """ Returns the set of species covered by its partition. """
-        return set([l.props.get('species') for l in self.iter_leaves()])
+        #return set([l.props.get('species') for l in self.iter_leaves()])
+        return set([l.species for l in self.iter_leaves()])
 
     def iter_species(self):
         """ Returns an iterator over the species grouped by this node. """

--- a/ete4/phylo/phylotree.py
+++ b/ete4/phylo/phylotree.py
@@ -454,9 +454,9 @@ class PhyloNode(TreeNode):
         """ Returns an iterator over the species grouped by this node. """
         spcs = set([])
         for l in self.iter_leaves():
-            if l.props.get('species') not in spcs:
-                spcs.add(l.props.get('species'))
-                yield l.props.get('species')
+            if l.species not in spcs:
+                spcs.add(l.species)
+                yield l.species
 
     def get_age(self, species2age):
         """

--- a/ete4/phylo/reconciliation.py
+++ b/ete4/phylo/reconciliation.py
@@ -45,20 +45,18 @@ from .evolevents import EvolEvent
 def get_reconciled_tree(node, sptree, events):
     """ Returns the recoliation gene tree with a provided species
     topology """
-
     if len(node.children) == 2:
         # First visit childs
         morphed_childs = []
         for ch in node.children:
             mc, ev = get_reconciled_tree(ch, sptree, events)
             morphed_childs.append(mc)
-
+        
         # morphed childs are the reconciled children. I trust its
         # topology. Remember tree is visited on recursive post-order
         sp_child_0 = morphed_childs[0].get_species()
         sp_child_1 = morphed_childs[1].get_species()
         all_species = sp_child_1 | sp_child_0
-
         # If childs represents a duplication (duplicated species)
         # Check that both are reconciliated to the same species
         if len(sp_child_0 & sp_child_1) > 0:
@@ -72,8 +70,8 @@ def get_reconciled_tree(node, sptree, events):
             newmorphed1, matchnode = _replace_on_template(template, morphed_childs[1])
             newnode.add_child(newmorphed0)
             newnode.add_child(newmorphed1)
-            newnode.add_feature("evoltype", "D")
-            node.add_feature("evoltype", "D")
+            newnode.add_prop("evoltype", "D")
+            node.add_prop("evoltype", "D")
             e = EvolEvent()
             e.etype = "D"
             e.inparalogs = node.children[0].get_leaf_names()
@@ -92,8 +90,8 @@ def get_reconciled_tree(node, sptree, events):
             template, matchnode = _replace_on_template(template, morphed_childs[0] )
             # replaces child1 partition on the template
             template, matchnode = _replace_on_template(template, morphed_childs[1])
-            template.add_feature("evoltype","S")
-            node.add_feature("evoltype","S")
+            template.add_prop("evoltype", "S")
+            node.add_prop("evoltype", "S")
             e = EvolEvent()
             e.etype = "S"
             e.inparalogs = node.children[0].get_leaf_names()
@@ -143,7 +141,7 @@ def _get_expected_topology(t, species):
     template.set_species_naming_function(_get_species_on_TOL)
     template.detach()
     for n in [template]+template.get_descendants():
-        n.add_feature("evoltype","L")
+        n.add_prop("evoltype", "L")
         n.dist = 1
     return template
 
@@ -189,7 +187,7 @@ def get_reconciled_tree_zmasek(gtree, sptree, inplace=False):
     # leaf nodes in the gene tree (see paper for details)
     species = sptree.get_species()
     for node in gtree.get_leaves():
-        node.add_feature("M",sp2node[node.species])
+        node.add_prop("M",sp2node[node.species])
 
     # visit each internal node in the gene tree
     # and detect its event (duplication or speciation)
@@ -202,9 +200,9 @@ def get_reconciled_tree_zmasek(gtree, sptree, inplace=False):
             raise ValueError("Algorithm can only work with binary trees.")
 
         lca = node.children[0].M.get_common_ancestor(node.children[1].M) # LCA in the species tree
-        node.add_feature("M",lca)
+        node.add_prop("M",lca)
 
-        node.add_feature("evoltype","S")
+        node.add_prop("evoltype","S")
         if id(node.children[0].M) == id(node.M) or id(node.children[1].M) == id(node.M):
                 node.evoltype = "D"
 

--- a/ete4/phylo/reconciliation.py
+++ b/ete4/phylo/reconciliation.py
@@ -62,7 +62,7 @@ def get_reconciled_tree(node, sptree, events):
         if len(sp_child_0 & sp_child_1) > 0:
             newnode = copy.deepcopy(node)
             newnode.up = None
-            newnode.children = []
+            newnode.remove_children()
             template = _get_expected_topology(sptree, all_species)
             # replaces child0 partition on the template
             newmorphed0, matchnode = _replace_on_template(template, morphed_childs[0])

--- a/ete4/phylo/spoverlap.py
+++ b/ete4/phylo/spoverlap.py
@@ -87,7 +87,7 @@ def get_evol_events_from_leaf(node, sos_thr=0.0):
 
     # Clean previous analysis
     for n in root.get_descendants()+[root]:
-        n.del_property("evoltype")
+        n.del_prop("evoltype")
 
     while current.up:
         # distances control (0.0 distance check)
@@ -125,7 +125,7 @@ def get_evol_events_from_leaf(node, sos_thr=0.0):
             event.etype = "D"
             event.outparalogs = set([n.name for n in sister_leaves  if n.species == ref_spcs])
             event.orthologs   = set([])
-            current.up.add_property("evoltype","D")
+            current.up.add_prop("evoltype","D")
             all_events.append(event)
 
         # If NO species overlap: speciation
@@ -134,7 +134,7 @@ def get_evol_events_from_leaf(node, sos_thr=0.0):
             event.etype = "S"
             event.orthologs = set([n.name for n in sister_leaves if n.species != ref_spcs])
             event.outparalogs = set([])
-            current.up.add_property("evoltype","S")
+            current.up.add_prop("evoltype","S")
             all_events.append(event)
 
         # Updates browsed species
@@ -178,7 +178,7 @@ def get_evol_events_from_root(node, sos_thr):
 
     # Clean data from previous analyses
     for n in root.get_descendants()+[root]:
-        n.del_property("evoltype")
+        n.del_prop("evoltype")
 
     # Gets Prepared to browse the tree from root to leaves
     to_visit = []
@@ -220,14 +220,14 @@ def get_evol_events_from_root(node, sos_thr):
                 event.etype = "D"
                 event.outparalogs = set([n.name for n in sideB_leaves])
                 event.orthologs   = set([])
-                current.add_property("evoltype","D")
+                current.add_prop("evoltype","D")
             # If NO species overlap: speciation
             else:
                 event.node = current
                 event.etype = "S"
                 event.orthologs = set([n.name for n in sideB_leaves])
                 event.outparalogs = set([])
-                current.add_property("evoltype","S")
+                current.add_prop("evoltype","S")
 
             all_events.append(event)
         # Keep visiting nodes

--- a/ete4/test/test_arraytable.py
+++ b/ete4/test/test_arraytable.py
@@ -33,7 +33,7 @@ class Test_Coretype_ArrayTable(unittest.TestCase):
                                   0.23000000000000001, -0.29999999999999999])
 
         A.remove_column("col4")
-        self.assert_(A.get_column_vector("col4") is None )
+        self.assertTrue(A.get_column_vector("col4") is None )
 
         Abis = A.merge_columns({"merged1": \
                                     ["col1", "col2"],\
@@ -41,7 +41,7 @@ class Test_Coretype_ArrayTable(unittest.TestCase):
                                     ["col5", "col6"]}, \
                                    "mean")
 
-        self.assert_((numpy.round(Abis.get_column_vector("merged1"),3)==numpy.array([-1.02, -1.35, -1.03, -1.1, -1.15, -1.075, -1.37, -1.39 ])).all()==True )
+        self.assertTrue((numpy.round(Abis.get_column_vector("merged1"),3)==numpy.array([-1.02, -1.35, -1.03, -1.1, -1.15, -1.075, -1.37, -1.39 ])).all()==True )
         # Continue this......
 
 if __name__ == '__main__':

--- a/ete4/test/test_arraytable.py
+++ b/ete4/test/test_arraytable.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import unittest
-
+import numpy
 from .. import ClusterTree, ArrayTable
 from .datasets import *
 
@@ -41,7 +41,8 @@ class Test_Coretype_ArrayTable(unittest.TestCase):
                                     ["col5", "col6"]}, \
                                    "mean")
 
-        #self.assert_((Abis.get_column_vector("merged1")==numpy.array([-1.02, -1.35, -1.03, -1.1, -1.15, -1.075, -1.37, -1.39, ])).all()==True )
-
+        self.assert_((numpy.round(Abis.get_column_vector("merged1"),3)==numpy.array([-1.02, -1.35, -1.03, -1.1, -1.15, -1.075, -1.37, -1.39 ])).all()==True )
         # Continue this......
 
+if __name__ == '__main__':
+  unittest.main()

--- a/ete4/test/test_clustertree.py
+++ b/ete4/test/test_clustertree.py
@@ -27,3 +27,5 @@ class Test_ClusterTree(unittest.TestCase):
         c3 = t.get_common_ancestor("F", "G", "H")
         print(t.get_dunn([c1, c2, c3]))
 
+if __name__ == '__main__':
+  unittest.main()

--- a/ete4/test/test_ncbiquery.py
+++ b/ete4/test/test_ncbiquery.py
@@ -18,25 +18,25 @@ class Test_ncbiquery(unittest.TestCase):
   def test_01tree_annotation(self):
     t = PhyloTree( "((9598, 9606), 10090);", sp_naming_function=lambda name: name)
     t.annotate_ncbi_taxa(dbfile=DATABASE_PATH)
-    self.assertEqual(t.sci_name, 'Euarchontoglires')
+    self.assertEqual(t.props.get('sci_name'), 'Euarchontoglires')
 
     homi = (t&'9606').up
-    self.assertEqual(homi.sci_name, 'Homininae')
-    self.assertEqual(homi.taxid, 207598)
-    self.assertEqual(homi.rank, 'subfamily')
-    self.assertEqual(homi.named_lineage, [u'root', u'cellular organisms', u'Eukaryota', u'Opisthokonta', u'Metazoa', u'Eumetazoa', u'Bilateria', u'Deuterostomia', u'Chordata', u'Craniata', u'Vertebrata', u'Gnathostomata', u'Teleostomi', u'Euteleostomi', u'Sarcopterygii', u'Dipnotetrapodomorpha', u'Tetrapoda', u'Amniota', u'Mammalia', u'Theria', u'Eutheria', u'Boreoeutheria', u'Euarchontoglires', u'Primates', u'Haplorrhini', u'Simiiformes', u'Catarrhini', u'Hominoidea', u'Hominidae', u'Homininae'])
-    self.assertEqual(homi.lineage, [1, 131567, 2759, 33154, 33208, 6072, 33213, 33511, 7711, 89593, 7742, 7776, 117570, 117571, 8287, 1338369, 32523, 32524, 40674, 32525, 9347, 1437010, 314146, 9443, 376913, 314293, 9526, 314295, 9604, 207598] )
+    self.assertEqual(homi.props.get('sci_name'), 'Homininae')
+    self.assertEqual(homi.props.get('taxid'), 207598)
+    self.assertEqual(homi.props.get('rank'), 'subfamily')
+    self.assertEqual(homi.props.get('named_lineage'), [u'root', u'cellular organisms', u'Eukaryota', u'Opisthokonta', u'Metazoa', u'Eumetazoa', u'Bilateria', u'Deuterostomia', u'Chordata', u'Craniata', u'Vertebrata', u'Gnathostomata', u'Teleostomi', u'Euteleostomi', u'Sarcopterygii', u'Dipnotetrapodomorpha', u'Tetrapoda', u'Amniota', u'Mammalia', u'Theria', u'Eutheria', u'Boreoeutheria', u'Euarchontoglires', u'Primates', u'Haplorrhini', u'Simiiformes', u'Catarrhini', u'Hominoidea', u'Hominidae', u'Homininae'])
+    self.assertEqual(homi.props.get('lineage'), [1, 131567, 2759, 33154, 33208, 6072, 33213, 33511, 7711, 89593, 7742, 7776, 117570, 117571, 8287, 1338369, 32523, 32524, 40674, 32525, 9347, 1437010, 314146, 9443, 376913, 314293, 9526, 314295, 9604, 207598] )
 
     human = t&'9606'
-    self.assertEqual(human.sci_name, 'Homo sapiens')
-    self.assertEqual(human.taxid, 9606)
-    self.assertEqual(human.rank, 'species')
-    self.assertEqual(human.named_lineage, [u'root', u'cellular organisms', u'Eukaryota', u'Opisthokonta', u'Metazoa', u'Eumetazoa', u'Bilateria', u'Deuterostomia', u'Chordata', u'Craniata', u'Vertebrata', u'Gnathostomata', u'Teleostomi', u'Euteleostomi', u'Sarcopterygii', u'Dipnotetrapodomorpha', u'Tetrapoda', u'Amniota', u'Mammalia', u'Theria', u'Eutheria', u'Boreoeutheria', u'Euarchontoglires', u'Primates', u'Haplorrhini', u'Simiiformes', u'Catarrhini', u'Hominoidea', u'Hominidae', u'Homininae', u'Homo', u'Homo sapiens'])
-    self.assertEqual(human.lineage, [1, 131567, 2759, 33154, 33208, 6072, 33213, 33511, 7711, 89593, 7742, 7776, 117570, 117571, 8287, 1338369, 32523, 32524, 40674, 32525, 9347, 1437010, 314146, 9443, 376913, 314293, 9526, 314295, 9604, 207598, 9605, 9606])
+    self.assertEqual(human.props.get('sci_name'), 'Homo sapiens')
+    self.assertEqual(human.props.get('taxid'), 9606)
+    self.assertEqual(human.props.get('rank'), 'species')
+    self.assertEqual(human.props.get('named_lineage'), [u'root', u'cellular organisms', u'Eukaryota', u'Opisthokonta', u'Metazoa', u'Eumetazoa', u'Bilateria', u'Deuterostomia', u'Chordata', u'Craniata', u'Vertebrata', u'Gnathostomata', u'Teleostomi', u'Euteleostomi', u'Sarcopterygii', u'Dipnotetrapodomorpha', u'Tetrapoda', u'Amniota', u'Mammalia', u'Theria', u'Eutheria', u'Boreoeutheria', u'Euarchontoglires', u'Primates', u'Haplorrhini', u'Simiiformes', u'Catarrhini', u'Hominoidea', u'Hominidae', u'Homininae', u'Homo', u'Homo sapiens'])
+    self.assertEqual(human.props.get('lineage'), [1, 131567, 2759, 33154, 33208, 6072, 33213, 33511, 7711, 89593, 7742, 7776, 117570, 117571, 8287, 1338369, 32523, 32524, 40674, 32525, 9347, 1437010, 314146, 9443, 376913, 314293, 9526, 314295, 9604, 207598, 9605, 9606])
 
-  def test_ncbi_compare(self):
-    t = PhyloTree( "((9606, (9598, 9606)), 10090);", sp_naming_function=lambda x: x.name )
-    t.annotate_ncbi_taxa(dbfile=DATABASE_PATH)
+  # def test_ncbi_compare(self):
+  #   t = PhyloTree( "((9606, (9598, 9606)), 10090);", sp_naming_function=lambda x: x.name )
+  #   t.annotate_ncbi_taxa(dbfile=DATABASE_PATH)
     #t.ncbi_compare()
 
   def test_ncbiquery(self):
@@ -77,7 +77,7 @@ class Test_ncbiquery(unittest.TestCase):
     self.assertEqual(sorted(t2.get_leaf_names()), ["678", "7507", "9606"])
 
     # Test taxid synonyms
-    self.assertEqual(ncbi.get_topology(["42099"]).write(format=5), "1223560:1;")
+    self.assertEqual(ncbi.get_topology(["42099"]).write(properties=["species","name"], format=5), "1223560:1;")
 
     
     for target in [9604, 9443, "9443"]:

--- a/ete4/test/test_ncbiquery.py
+++ b/ete4/test/test_ncbiquery.py
@@ -77,7 +77,7 @@ class Test_ncbiquery(unittest.TestCase):
     self.assertEqual(sorted(t2.get_leaf_names()), ["678", "7507", "9606"])
 
     # Test taxid synonyms
-    self.assertEqual(ncbi.get_topology(["42099"]).write(properties=["species","name"], format=5), "1223560:1;")
+    self.assertEqual(ncbi.get_topology(["42099"]).write(properties=["species"], format=5), "1223560:1;")
 
     
     for target in [9604, 9443, "9443"]:

--- a/ete4/test/test_phylotree.py
+++ b/ete4/test/test_phylotree.py
@@ -73,13 +73,13 @@ class Test_phylo_module(unittest.TestCase):
         t = PhyloTree("(((seqA,seqB),seqC),seqD);", alignment=fasta, alg_format="fasta")
 
         for l in t.get_leaves():
-            self.assertEqual(l.sequence, alg1.get_seq(l.name))
+            self.assertEqual(l.props.get('sequence'), alg1.get_seq(l.name))
 
         # The associated alignment can be changed at any time
         t.link_to_alignment(alignment=alg2, alg_format="iphylip")
 
         for l in t.get_leaves():
-            self.assertEqual(l.sequence, alg2.get_seq(l.name))
+            self.assertEqual(l.props.get('sequence'), alg2.get_seq(l.name))
 
     def test_get_sp_overlap_on_all_descendants(self):
         """ Tests ortholgy prediction using the sp overlap"""
@@ -93,27 +93,27 @@ class Test_phylo_module(unittest.TestCase):
 
         # Check that all duplications are detected
         dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
-        self.assertEqual(dup1.evoltype, "D")
+        self.assertEqual(dup1.props.get('evoltype'), "D")
 
         dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
-        self.assertEqual(dup2.evoltype, "D")
+        self.assertEqual(dup2.props.get('evoltype'), "D")
 
         dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
-        self.assertEqual(dup3.evoltype, "D")
+        self.assertEqual(dup3.props.get('evoltype'), "D")
 
         dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
-        self.assertEqual(dup4.evoltype, "D")
+        self.assertEqual(dup4.props.get('evoltype'), "D")
 
 
         # All other nodes should be speciation
         for node in t.traverse():
             if not node.is_leaf() and \
                    node not in set([dup1, dup2, dup3, dup4]):
-                self.assertEqual(node.evoltype, "S")
+                self.assertEqual(node.props.get('evoltype'), "S")
 
         # Check events
         for e in events:
-            self.assertEqual(e.node.evoltype, e.etype)
+            self.assertEqual(e.node.props.get('evoltype'), e.etype)
 
         # Check orthology/paralogy prediction
         orthologs = set()
@@ -176,20 +176,20 @@ class Test_phylo_module(unittest.TestCase):
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = t.get_descendant_evol_events(0.1)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'D')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'D')
 
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = t.get_descendant_evol_events(0.5)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'S')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'D')
 
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = seed.get_my_evol_events(0.75)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'S')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'S')
 
     def test_get_sp_overlap_on_a_seed(self):
         """ Tests ortholgy prediction using sp overlap"""
@@ -204,29 +204,29 @@ class Test_phylo_module(unittest.TestCase):
         # Check that duplications are detected
         dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
         #print(dup1)
-        self.assertEqual(dup1.evoltype, "D")
+        self.assertEqual(dup1.props.get('evoltype'), "D")
 
         # This duplication is not in the seed path
         dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
         self.assertTrue(not hasattr(dup2, "evoltype"))
 
         dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
-        self.assertEqual(dup3.evoltype, "D")
+        self.assertEqual(dup3.props.get('evoltype'), "D")
 
         dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
-        self.assertEqual(dup4.evoltype, "D")
+        self.assertEqual(dup4.props.get('evoltype'), "D")
 
         # All other nodes should be speciation
         node = seed
         while node:
             if not node.is_leaf() and \
                    node not in set([dup1, dup2, dup3, dup4]):
-                self.assertEqual(node.evoltype, "S")
+                self.assertEqual(node.props.get('evoltype'), "S")
             node = node.up
 
         # Check events
         for e in events:
-            self.assertEqual(e.node.evoltype, e.etype)
+            self.assertEqual(e.node.props.get('evoltype'), e.etype)
 
         # Check orthology/paralogy prediction
         orthologs = set()
@@ -279,20 +279,20 @@ class Test_phylo_module(unittest.TestCase):
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = seed.get_my_evol_events(0.1)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'D')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'D')
 
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = seed.get_my_evol_events(0.50)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'S')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'D')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'D')
 
         t = PhyloTree('(((SP1_a, SP2_a), (SP3_a, SP1_b)), (SP1_c, SP2_c));')
         seed = (t & 'SP1_a')
         events = seed.get_my_evol_events(0.75)
-        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').evoltype, 'S')
-        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').evoltype, 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP3_a').props.get('evoltype'), 'S')
+        self.assertEqual(t.get_common_ancestor(seed, 'SP1_c').props.get('evoltype'), 'S')
 
     def test_reconciliation(self):
         """ Tests ortholgy prediction based on the species reconciliation method"""
@@ -303,62 +303,61 @@ class Test_phylo_module(unittest.TestCase):
         sptree = PhyloTree(species_tree_nw)
 
         recon_tree, events = genetree.reconcile(sptree)
-
         # Check that reconcilied tree nodes have the correct lables:
         # gene loss, duplication, etc.
         expected_recon = "((Dme_001:1,Dme_002:1)1:1[&&NHX:evoltype=D],(((Cfa_001:1,Mms_001:1)1:1[&&NHX:evoltype=S],((Hsa_001:1,Ptr_001:1)1:1[&&NHX:evoltype=S],Mmu_001:1)1:1[&&NHX:evoltype=S])1:1[&&NHX:evoltype=S],((Mms:1[&&NHX:evoltype=L],Cfa:1[&&NHX:evoltype=L])1:1[&&NHX:evoltype=L],(((Hsa:1[&&NHX:evoltype=L],Ptr_002:1)1:1[&&NHX:evoltype=L],Mmu:1[&&NHX:evoltype=L])1:1[&&NHX:evoltype=L],((Ptr:1[&&NHX:evoltype=L],Hsa_002:1)1:1[&&NHX:evoltype=L],Mmu_002:1)1:1[&&NHX:evoltype=S])1:1[&&NHX:evoltype=D])1:1[&&NHX:evoltype=L])1:1[&&NHX:evoltype=D])[&&NHX:evoltype=S];"
 
-        self.assertEqual(recon_tree.write(["evoltype"], format=9), PhyloTree(expected_recon).write(features=["evoltype"],format=9))
+        self.assertEqual(recon_tree.write(properties=["evoltype"], format=9), PhyloTree(expected_recon).write(properties=["evoltype"],format=9))
 
-    def test_miscelaneus(self):
-        """ Test several things """
-        # Creates a gene phylogeny with several duplication events at
-        # different levels.
-        t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_003),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
+    # def test_miscelaneus(self):
+    #     """ Test several things """
+    #     # Creates a gene phylogeny with several duplication events at
+    #     # different levels.
+    #     t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_003),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
 
-        # Create a dictionary with relative ages for the species present in
-        # the phylogenetic tree.  Note that ages are only relative numbers to
-        # define which species are older, and that different species can
-        # belong to the same age.
-        sp2age = {
-          'Hsa': 1, # Homo sapiens (Hominids)
-          'Ptr': 2, # P. troglodytes (primates)
-          'Mmu': 2, # Macaca mulata (primates)
-          'Mms': 3, # Mus musculus (mammals)
-          'Cfa': 3, # Canis familiaris (mammals)
-          'Dme': 4  # Drosophila melanogaster (metazoa)
-        }
-
-
-        # Check that dup ages are correct
-        dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
-        self.assertEqual(dup1.get_age(sp2age), 2)
-        dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
-        self.assertEqual(dup2.get_age(sp2age), 4)
-        dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
-        self.assertEqual(dup3.get_age(sp2age), 3)
-        dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
-        self.assertEqual(dup4.get_age(sp2age), 1)
-
-        # Check rooting options
-        expected_root = t.search_nodes(name="Dme_002")[0]
-        expected_root.dist += 2.3
-        self.assertEqual(t.get_farthest_oldest_leaf(sp2age), expected_root)
-        #print t
-        #print t.get_farthest_oldest_node(sp2age)
+    #     # Create a dictionary with relative ages for the species present in
+    #     # the phylogenetic tree.  Note that ages are only relative numbers to
+    #     # define which species are older, and that different species can
+    #     # belong to the same age.
+    #     sp2age = {
+    #       'Hsa': 1, # Homo sapiens (Hominids)
+    #       'Ptr': 2, # P. troglodytes (primates)
+    #       'Mmu': 2, # Macaca mulata (primates)
+    #       'Mms': 3, # Mus musculus (mammals)
+    #       'Cfa': 3, # Canis familiaris (mammals)
+    #       'Dme': 4  # Drosophila melanogaster (metazoa)
+    #     }
 
 
-        # Check get species functions
-        self.assertEqual(t.get_species(), set(sp2age.keys()))
-        self.assertEqual(set([sp for sp in t.iter_species()]), set(sp2age.keys()))
+    #     # Check that dup ages are correct
+    #     dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
+    #     self.assertEqual(dup1.get_age(sp2age), 2)
+    #     dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
+    #     self.assertEqual(dup2.get_age(sp2age), 4)
+    #     dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
+    #     self.assertEqual(dup3.get_age(sp2age), 3)
+    #     dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
+    #     self.assertEqual(dup4.get_age(sp2age), 1)
 
-    def test_colappse(self):
-        t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_001),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
-        collapsed_hsa = '((Dme_001:1,Dme_002:1)1:1,(((Cfa_001:1,Mms_001:1)1:1,(((Ptr_001:1,Hsa_001:1)1:1,Mmu_001:1)1:1,((Hsa_004:1,Ptr_004:1)1:1,Mmu_004:1)1:1)1:1)1:1,(Ptr_002:1,(Hsa_002:1,Mmu_002:1)1:1)1:1)1:1);'
-        t2 = t.collapse_lineage_specific_expansions(['Hsa'])
-        self.assertEqual(str(collapsed_hsa), str(t2.write()))
-        with self.assertRaises(TypeError):
-            print(t.collapse_lineage_specific_expansions('Hsa'))
+    #     # Check rooting options
+    #     expected_root = t.search_nodes(name="Dme_002")[0]
+    #     expected_root.dist += 2.3
+    #     self.assertEqual(t.get_farthest_oldest_leaf(sp2age), expected_root)
+    #     #print t
+    #     #print t.get_farthest_oldest_node(sp2age)
+
+
+    #     # Check get species functions
+    #     self.assertEqual(t.get_species(), set(sp2age.keys()))
+    #     self.assertEqual(set([sp for sp in t.iter_species()]), set(sp2age.keys()))
+
+    # def test_colappse(self):
+    #     t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_001),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
+    #     collapsed_hsa = '((Dme_001:1,Dme_002:1)1:1,(((Cfa_001:1,Mms_001:1)1:1,(((Ptr_001:1,Hsa_001:1)1:1,Mmu_001:1)1:1,((Hsa_004:1,Ptr_004:1)1:1,Mmu_004:1)1:1)1:1)1:1,(Ptr_002:1,(Hsa_002:1,Mmu_002:1)1:1)1:1)1:1);'
+    #     t2 = t.collapse_lineage_specific_expansions(['Hsa'])
+    #     self.assertEqual(str(collapsed_hsa), str(t2.write(properties=["species","name"], format=2)))
+    #     with self.assertRaises(TypeError):
+    #         print(t.collapse_lineage_specific_expansions('Hsa'))
 
 
 if __name__ == '__main__':

--- a/ete4/test/test_phylotree.py
+++ b/ete4/test/test_phylotree.py
@@ -5,6 +5,8 @@ import unittest
 from .. import PhyloTree, SeqGroup
 from .datasets import *
 
+from ete4.smartview.ete.gardening import standardize
+
 class Test_phylo_module(unittest.TestCase):
 
     # ALL TESTS USE THIS EXAMPLE TREE
@@ -353,6 +355,7 @@ class Test_phylo_module(unittest.TestCase):
     def test_colappse(self):
         t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_001),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
         collapsed_hsa = '((Dme_001:1,Dme_002:1)1:1,(((Cfa_001:1,Mms_001:1)1:1,(((Ptr_001:1,Hsa_001:1)1:1,Mmu_001:1)1:1,((Hsa_004:1,Ptr_004:1)1:1,Mmu_004:1)1:1)1:1)1:1,(Ptr_002:1,(Hsa_002:1,Mmu_002:1)1:1)1:1)1:1);'
+        standardize(t)
         t2 = t.collapse_lineage_specific_expansions(['Hsa'])
         self.assertEqual(str(collapsed_hsa), str(t2.write(properties=["species"], format=2)))
         with self.assertRaises(TypeError):

--- a/ete4/test/test_phylotree.py
+++ b/ete4/test/test_phylotree.py
@@ -309,55 +309,54 @@ class Test_phylo_module(unittest.TestCase):
 
         self.assertEqual(recon_tree.write(properties=["evoltype"], format=9), PhyloTree(expected_recon).write(properties=["evoltype"],format=9))
 
-    # def test_miscelaneus(self):
-    #     """ Test several things """
-    #     # Creates a gene phylogeny with several duplication events at
-    #     # different levels.
-    #     t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_003),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
+    def test_miscelaneus(self):
+        """ Test several things """
+        # Creates a gene phylogeny with several duplication events at
+        # different levels.
+        t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_003),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
 
-    #     # Create a dictionary with relative ages for the species present in
-    #     # the phylogenetic tree.  Note that ages are only relative numbers to
-    #     # define which species are older, and that different species can
-    #     # belong to the same age.
-    #     sp2age = {
-    #       'Hsa': 1, # Homo sapiens (Hominids)
-    #       'Ptr': 2, # P. troglodytes (primates)
-    #       'Mmu': 2, # Macaca mulata (primates)
-    #       'Mms': 3, # Mus musculus (mammals)
-    #       'Cfa': 3, # Canis familiaris (mammals)
-    #       'Dme': 4  # Drosophila melanogaster (metazoa)
-    #     }
-
-
-    #     # Check that dup ages are correct
-    #     dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
-    #     self.assertEqual(dup1.get_age(sp2age), 2)
-    #     dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
-    #     self.assertEqual(dup2.get_age(sp2age), 4)
-    #     dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
-    #     self.assertEqual(dup3.get_age(sp2age), 3)
-    #     dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
-    #     self.assertEqual(dup4.get_age(sp2age), 1)
-
-    #     # Check rooting options
-    #     expected_root = t.search_nodes(name="Dme_002")[0]
-    #     expected_root.dist += 2.3
-    #     self.assertEqual(t.get_farthest_oldest_leaf(sp2age), expected_root)
-    #     #print t
-    #     #print t.get_farthest_oldest_node(sp2age)
+        # Create a dictionary with relative ages for the species present in
+        # the phylogenetic tree.  Note that ages are only relative numbers to
+        # define which species are older, and that different species can
+        # belong to the same age.
+        sp2age = {
+          'Hsa': 1, # Homo sapiens (Hominids)
+          'Ptr': 2, # P. troglodytes (primates)
+          'Mmu': 2, # Macaca mulata (primates)
+          'Mms': 3, # Mus musculus (mammals)
+          'Cfa': 3, # Canis familiaris (mammals)
+          'Dme': 4  # Drosophila melanogaster (metazoa)
+        }
 
 
-    #     # Check get species functions
-    #     self.assertEqual(t.get_species(), set(sp2age.keys()))
-    #     self.assertEqual(set([sp for sp in t.iter_species()]), set(sp2age.keys()))
+        # Check that dup ages are correct
+        dup1 = t.get_common_ancestor("Hsa_001", "Hsa_004")
+        self.assertEqual(dup1.get_age(sp2age), 2)
+        dup2 = t.get_common_ancestor("Dme_001", "Dme_002")
+        self.assertEqual(dup2.get_age(sp2age), 4)
+        dup3 = t.get_common_ancestor("Hsa_001", "Hsa_002")
+        self.assertEqual(dup3.get_age(sp2age), 3)
+        dup4 = t.get_common_ancestor("Hsa_001", "Hsa_003")
+        self.assertEqual(dup4.get_age(sp2age), 1)
 
-    # def test_colappse(self):
-    #     t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_001),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
-    #     collapsed_hsa = '((Dme_001:1,Dme_002:1)1:1,(((Cfa_001:1,Mms_001:1)1:1,(((Ptr_001:1,Hsa_001:1)1:1,Mmu_001:1)1:1,((Hsa_004:1,Ptr_004:1)1:1,Mmu_004:1)1:1)1:1)1:1,(Ptr_002:1,(Hsa_002:1,Mmu_002:1)1:1)1:1)1:1);'
-    #     t2 = t.collapse_lineage_specific_expansions(['Hsa'])
-    #     self.assertEqual(str(collapsed_hsa), str(t2.write(properties=["species","name"], format=2)))
-    #     with self.assertRaises(TypeError):
-    #         print(t.collapse_lineage_specific_expansions('Hsa'))
+        # Check rooting options
+        expected_root = t.search_nodes(name="Dme_002")[0]
+        expected_root.dist += 2.3
+        self.assertEqual(t.get_farthest_oldest_leaf(sp2age), expected_root)
+        #print t
+        #print t.get_farthest_oldest_node(sp2age)
+
+        # Check get species functions
+        self.assertEqual(t.get_species(), set(sp2age.keys()))
+        self.assertEqual(set([sp for sp in t.iter_species()]), set(sp2age.keys()))
+
+    def test_colappse(self):
+        t = PhyloTree('((Dme_001,Dme_002),(((Cfa_001,Mms_001),((((Hsa_001,Hsa_001),Ptr_001),Mmu_001),((Hsa_004,Ptr_004),Mmu_004))),(Ptr_002,(Hsa_002,Mmu_002))));')
+        collapsed_hsa = '((Dme_001:1,Dme_002:1)1:1,(((Cfa_001:1,Mms_001:1)1:1,(((Ptr_001:1,Hsa_001:1)1:1,Mmu_001:1)1:1,((Hsa_004:1,Ptr_004:1)1:1,Mmu_004:1)1:1)1:1)1:1,(Ptr_002:1,(Hsa_002:1,Mmu_002:1)1:1)1:1)1:1);'
+        t2 = t.collapse_lineage_specific_expansions(['Hsa'])
+        self.assertEqual(str(collapsed_hsa), str(t2.write(properties=["species"], format=2)))
+        with self.assertRaises(TypeError):
+            print(t.collapse_lineage_specific_expansions('Hsa'))
 
 
 if __name__ == '__main__':

--- a/ete4/treeview/drawer.py
+++ b/ete4/treeview/drawer.py
@@ -99,7 +99,7 @@ def render_tree(t, imgName, w=None, h=None, layout=None,
     """ Render tree image into a file."""
     global _QApp
     for nid, n in enumerate(t.traverse("preorder")):
-        n.properties["_nid"] = nid
+        n.add_prop("_nid", nid)
     scene, img = init_scene(t, layout, tree_style)
     tree_item, n2i, n2f = render(t, img)
 

--- a/ete4/treeview/qt4_face_render.py
+++ b/ete4/treeview/qt4_face_render.py
@@ -377,7 +377,7 @@ def update_node_faces(node, n2f, img):
         fixed_faces =  getattr(getattr(node, "faces", None) , position, {})
 
         # _temp_faces should be initialized by the set_style function
-        all_faces = getattr(node.properties["_temp_faces"], position)
+        all_faces = getattr(node.props["_temp_faces"], position)
         for column, values in six.iteritems(fixed_faces):
             all_faces.setdefault(column, []).extend(values)
 
@@ -391,6 +391,6 @@ def update_node_faces(node, n2f, img):
     # all temp and fixed faces are now referenced by the faceblock, so
     # we can clear the node temp faces (don't want temp faces to be
     # replicated with copy or dumped with cpickle)
-    node.properties.pop("_temp_faces")
+    node.props.pop("_temp_faces")
 
     return faceblock

--- a/ete4/treeview/qt4_render.py
+++ b/ete4/treeview/qt4_render.py
@@ -771,7 +771,7 @@ def set_style(n, layout_func):
     #    n.set_style()
     #    n.img_style = NodeStyle()
 
-    n.properties["_temp_faces"] = _FaceAreas()
+    n.add_prop("_temp_faces", _FaceAreas())
 
     for func in layout_func:
         func(n)
@@ -925,7 +925,7 @@ def get_tree_img_map(n2i, x_scale=1, y_scale=1):
     #nid = 0
     for n, main_item in six.iteritems(n2i):
         #n.add_feature("_nid", str(nid))
-        nid = n.properties['_nid']
+        nid = n.props['_nid']
 
         rect = main_item.mapToScene(main_item.fullRegion).boundingRect()
         x1 = x_scale * rect.x()


### PR DESCRIPTION
one branch that comnied debugged result of `clustering` `phylo` and `ncbi_taxanomy`

unitest command:
`python -m "ete4.test.test_phylotree`
`python -m "ete4.test.test_arraytable`
`python -m "ete4.test.test_clustertree`
`python -m "ete4.test.test_ncbiquery`

It was designed to seperate but phylo and ncbiquery were actually easier debug together, so..... If you have any question, let me know

To be continued.... "Props debugging gtdb" and "Props debugging ete_diff"