### PR TITLE
Ncbi update option

### DIFF
--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -97,7 +97,7 @@ class NCBITaxa(object):
     Provides a local transparent connector to the NCBI taxonomy database.
     """
 
-    def __init__(self, dbfile=None, taxdump_file=None):
+    def __init__(self, dbfile=None, taxdump_file=None, update=True):
 
         if not dbfile:
             self.dbfile = DEFAULT_TAXADB
@@ -109,7 +109,8 @@ class NCBITaxa(object):
 
         if dbfile != DEFAULT_TAXADB and not os.path.exists(self.dbfile):
             print('NCBI database not present yet (first time used?)', file=sys.stderr)
-            self.update_taxonomy_database(taxdump_file)
+            if update:
+                self.update_taxonomy_database(taxdump_file)
 
         if not os.path.exists(self.dbfile):
             raise ValueError("Cannot open taxonomy database: %s" % self.dbfile)

--- a/ete3/ncbi_taxonomy/ncbiquery.py
+++ b/ete3/ncbi_taxonomy/ncbiquery.py
@@ -109,8 +109,7 @@ class NCBITaxa(object):
 
         if dbfile != DEFAULT_TAXADB and not os.path.exists(self.dbfile):
             print('NCBI database not present yet (first time used?)', file=sys.stderr)
-            if update:
-                self.update_taxonomy_database(taxdump_file)
+            self.update_taxonomy_database(taxdump_file)
 
         if not os.path.exists(self.dbfile):
             raise ValueError("Cannot open taxonomy database: %s" % self.dbfile)
@@ -118,7 +117,7 @@ class NCBITaxa(object):
         self.db = None
         self._connect()
 
-        if not is_taxadb_up_to_date(self.dbfile):
+        if not is_taxadb_up_to_date(self.dbfile) and update:
             print('NCBI database format is outdated. Upgrading', file=sys.stderr)
             self.update_taxonomy_database(taxdump_file)
 

--- a/sdoc/tutorial/tutorial_ncbitaxonomy.rst
+++ b/sdoc/tutorial/tutorial_ncbitaxonomy.rst
@@ -26,20 +26,41 @@ database (~300MB) and will store a parsed version of it in your home directory:
 local database and will skip this step.
 
 ::
+
    from ete3 import NCBITaxa
    ncbi = NCBITaxa()
 
-Upgrading the local database
-------------------------------
-
-Use the method :NCBITaxa:`update_taxonomy_database` to download and parse the
-latest database from the NCBI ftp site. Your current local database will be
-overwritten.
+Further the class provides the option to set a specific path for the data base
+location,
 
 ::
 
    from ete3 import NCBITaxa
-   ncbi = NCBITaxa()
+   ncbi = NCBITaxa(dbfile="/path/to/.etetoolkit/taxa.sqlite")
+
+
+and an option to specify a local taxdump file. If you wish to make your script
+reproducible. 
+
+::
+
+   from ete3 import NCBITaxa
+   ncbi = NCBITaxa(taxdump_file="/path/to/.etetoolkit/taxa.sqlite")
+
+
+Upgrading the local database
+------------------------------
+
+Every time :class:`NCBITaxa` is initialized the data base is updated if needed.
+If the user wants to manage the update by hand :class:`NCBITaxa` can be
+initialized without updating by setting the appropriate option.  Use the method
+:NCBITaxa:`update_taxonomy_database` to download and parse the latest database
+from the NCBI ftp site. Your current local database will be overwritten.
+
+::
+
+   from ete3 import NCBITaxa
+   ncbi = NCBITaxa(update=False)
    ncbi.update_taxonomy_database()
 
 


### PR DESCRIPTION
I ran into problems using the NCBITaxa class.
Initiating the class always triggers a check if the current data base is not up to date. This causes other processes to throw sqlite errors when they want to access the database at the same time.

Therefore I added an option on initializing the class to not update the database. The default in this pull request still is that an automatic update is triggered, hence this pull request is down stream compatible. If any software relies on the automatic update on class initialization.

I changed the official documentation to clarify the way how the data base can be updated. And further added a few explanation on some option regarding the initialization of the class and a formatting error.

Currently I need some try and except statement to catch the sqlite errors in my own project. This could be avoided with this pull request.

If you find this helpful I would be glad if you merge it.

Thanks
John