### PR TITLE
replaced 'is' with '=='

### DIFF
--- a/ete3/evol/parser/codemlparser.py
+++ b/ete3/evol/parser/codemlparser.py
@@ -218,7 +218,7 @@ def parse_paml (pamout, model):
         model._tree._label_as_paml()
     # starts parsing
     for i, line in enumerate (all_lines):
-        if line is '\n':
+        if line == '\n':
             continue
         # codon frequency
         if line.startswith('Codon frequencies under model'):


### PR DESCRIPTION
Newer versions of Python (>=3.8) emit a syntax warning when the _is_ operator is used with string literals. This happens in codemlparser.py when a string is compared with '\n', which causes an annoying syntax warning when importing ete3.

This fixes #504 (which references a description of the syntax warning: https://bugs.python.org/issue34850).