### PR TITLE
Goes back to original newick parser and rooting function

### DIFF
--- a/ete4/coretype/tree.pyx
+++ b/ete4/coretype/tree.pyx
@@ -50,6 +50,7 @@ import six
 from six.moves import (cPickle, map, range, zip)
 
 from .. import utils
+from ..parser.newick import read_newick, write_newick 
 
 # the following imports are necessary to set fixed styles and faces
 # try:
@@ -59,8 +60,8 @@ try:
 except ImportError: 
     pass # Treeview is now an optional dependency
 
-from ete4.smartview import Face as smartFace
-from ete4.smartview.ete.face_positions import FACE_POSITIONS, _FaceAreas, get_FaceAreas
+from ..smartview import Face as smartFace
+from ..smartview.ete.face_positions import FACE_POSITIONS, _FaceAreas, get_FaceAreas
 # except ImportError:
     # TREEVIEW = False
 # else:
@@ -139,13 +140,19 @@ cdef class TreeNode(object):
         t3 = Tree('/home/user/myNewickFile.txt')
     """
 
+    # def __getattr__(self, item):
+    #     try:
+    #         return super(TreeNode, self).__getattr__(item)
+    #     except AttributeError:
+    #         return self._properties[item]
+
     def _get_name(self):
-        return self._properties.get('name')
+        return self._properties.get('name', DEFAULT_NAME)
     def _set_name(self, value):
         self._properties['name'] = value
 
     def _get_dist(self):
-        return self._properties.get('dist')
+        return self._properties.get('dist', DEFAULT_DIST)
     def _set_dist(self, value):
         try:
             self._properties['dist'] = float(value)
@@ -153,7 +160,7 @@ cdef class TreeNode(object):
             raise TreeError('node dist must be a float number')
 
     def _get_support(self):
-        return self._properties.get('support')
+        return self._properties.get('support', DEFAULT_SUPPORT)
     def _set_support(self, value):
         try:
             self._properties['support'] = float(value)
@@ -269,8 +276,7 @@ cdef class TreeNode(object):
 
         # Initialize tree
         if newick is not None:
-            from ete4.parser.newick import read_newick
-            read_newick(newick, self)
+            read_newick(newick, self, format=format, quoted_names=quoted_node_names)
         
         self.name = name if name is not None else\
                 self.name if self.name is not None else DEFAULT_NAME
@@ -367,7 +373,7 @@ cdef class TreeNode(object):
         """
         Permanently deletes a node's feature.
         """
-        print("\nWARNING! del_prop is DEPRECATED use del_prop instead\n")
+        print("\nWARNING! del_feature is DEPRECATED use del_prop instead\n")
         self.del_prop(pr_name)
     # DEPRECATED #
 
@@ -905,7 +911,7 @@ cdef class TreeNode(object):
         print("Most distant node:\t%s" %max_node.name)
         print("Max. distance:\t%f" %max_dist)
 
-    def write(self, properties=[], outfile=None, format=0, is_leaf_fn=None,
+    def write(self, properties=None, outfile=None, format=0, is_leaf_fn=None,
               format_root_node=False, dist_formatter=None, support_formatter=None,
               name_formatter=None, quoted_node_names=False):
         """
@@ -913,18 +919,17 @@ cdef class TreeNode(object):
         arguments control the way in which extra data is shown for
         every node:
 
-        :argument properties: a list of feature names to be exported
-          using the Extended Newick Format (i.e. properties=["name",
-          "dist"]). Use an empty list to export all available properties
-          in each node (properties=[]), assign it None to mute all the 
-          properties (properties=None)
+        :argument features: a list of feature names to be exported
+          using the Extended Newick Format (i.e. features=["name",
+          "dist"]). Use an empty list to export all available features
+          in each node (features=[])
 
         :argument outfile: writes the output to a given file
 
         :argument format: defines the newick standard used to encode the
           tree. See tutorial for details.
 
-        :argument False format_root_node: If True, it allows properties
+        :argument False format_root_node: If True, it allows features
           and branch information from root node to be exported as a
           part of the newick text string. For newick compatibility
           reasons, this is False by default.
@@ -936,18 +941,17 @@ cdef class TreeNode(object):
 
         ::
 
-             t.write(properties=["species","name"], format=1, outfile="mytree.nwx")
+             t.write(features=["species","name"], format=1)
 
         """
 
-        from ete4.parser.newick import set_formatters, write_newick
-        # Set dist, support and name formatters
-        set_formatters(dist_formatter=dist_formatter,
-                       support_formatter=support_formatter,
-                       name_formatter=name_formatter)
-
-        nw = write_newick(self, format=format, properties=properties,
-                quoted_names=quoted_node_names)
+        nw = write_newick(self, properties=properties, format=format,
+                          is_leaf_fn=is_leaf_fn,
+                          format_root_node=format_root_node,
+                          dist_formatter=dist_formatter,
+                          support_formatter=support_formatter,
+                          name_formatter=name_formatter,
+                          quoted_names=quoted_node_names)
 
         if outfile is not None:
             with open(outfile, "w") as OUT:
@@ -1344,7 +1348,8 @@ cdef class TreeNode(object):
                 tname = ''.join(next(avail_names))
             n.name = tname
 
-    def set_outgroup(self, outgroup, branch_properties=None):
+    
+    def set_outgroup_jordi(self, outgroup, branch_properties=None):
         """
         Returns a descendant node as the outgroup of a tree.  This function
         can be used to root a tree or even an internal node.
@@ -1353,8 +1358,97 @@ cdef class TreeNode(object):
           structure that will be used as a basal node.
         :branch_properties: list of branch properties (other than "support").
         """
-        from ete4.smartview.ete.gardening import root_at
+        from ..smartview.ete.gardening import root_at
         return root_at(outgroup, branch_properties)
+
+
+
+    def set_outgroup(self, outgroup):
+        """
+        Sets a descendant node as the outgroup of a tree.  This function
+        can be used to root a tree or even an internal node.
+
+        :argument outgroup: a node instance within the same tree
+          structure that will be used as a basal node.
+
+        """
+        from ..smartview.ete.gardening import update_all_sizes
+        outgroup = _translate_nodes(self, outgroup)
+
+        if self == outgroup:
+            raise TreeError("Cannot set the tree root as outgroup")
+
+        parent_outgroup = outgroup.up
+
+        # Detects (sub)tree root
+        n = outgroup
+        while n.up is not self:
+            n = n.up
+
+        # If outgroup is a child from root, but with more than one
+        # sister nodes, creates a new node to group them
+        self.children.remove(n)
+        if len(self.children) != 1:
+            down_branch_connector = self.__class__()
+            down_branch_connector.dist = 0.0
+            down_branch_connector.support = n.support
+            for ch in self.get_children():
+                down_branch_connector.children.append(ch)
+                ch.up = down_branch_connector
+                self.children.remove(ch)
+        else:
+            down_branch_connector = self.children[0]
+
+        # Connects down branch to myself or to outgroup
+        quien_va_ser_padre = parent_outgroup
+        if quien_va_ser_padre is not self:
+            # Parent-child swapping
+            quien_va_ser_hijo = quien_va_ser_padre.up
+            quien_fue_padre = None
+            buffered_dist = quien_va_ser_padre.dist
+            buffered_support = quien_va_ser_padre.support
+
+            while quien_va_ser_hijo is not self:
+                quien_va_ser_padre.children.append(quien_va_ser_hijo)
+                quien_va_ser_hijo.children.remove(quien_va_ser_padre)
+
+                buffered_dist2 = quien_va_ser_hijo.dist
+                buffered_support2 = quien_va_ser_hijo.support
+                quien_va_ser_hijo.dist = buffered_dist
+                quien_va_ser_hijo.support = buffered_support
+                buffered_dist = buffered_dist2
+                buffered_support = buffered_support2
+
+                quien_va_ser_padre.up = quien_fue_padre
+                quien_fue_padre = quien_va_ser_padre
+
+                quien_va_ser_padre = quien_va_ser_hijo
+                quien_va_ser_hijo = quien_va_ser_padre.up
+
+            quien_va_ser_padre.children.append(down_branch_connector)
+            down_branch_connector.up = quien_va_ser_padre
+            quien_va_ser_padre.up = quien_fue_padre
+
+            down_branch_connector.dist += buffered_dist
+            outgroup2 = parent_outgroup
+            parent_outgroup.children.remove(outgroup)
+            outgroup2.dist = 0
+
+        else:
+            outgroup2 = down_branch_connector
+
+        outgroup.up = self
+        outgroup2.up = self
+        # outgroup is always the first children. Some function my
+        # trust on this fact, so do no change this.
+        self.children = [outgroup,outgroup2]
+        middist = (outgroup2.dist + outgroup.dist)/2
+        outgroup.dist = middist
+        outgroup2.dist = middist
+        outgroup2.support = outgroup.support
+
+        update_all_sizes(self)
+
 
     def unroot(self, mode='legacy'):
         """
@@ -1443,7 +1537,7 @@ cdef class TreeNode(object):
 
         :port: port used to run the local server (127.0.0.1). Default 5000
         """
-        from ete4.smartview.gui.server import run_smartview
+        from ..smartview.gui.server import run_smartview
 
         run_smartview(tree=self, tree_name=tree_name, 
                 tree_style=tree_style, layouts=layouts, port=port)
@@ -1480,9 +1574,9 @@ cdef class TreeNode(object):
         """
         method = method.lower()
         if method=="newick":
-            new_node = self.__class__(self.write(properties=["name"], format=1)) #, format_root_node=True))
+            new_node = self.__class__(self.write(properties=None, format=1, format_root_node=True), format=1)
         elif method=="newick-extended":
-            new_node = self.__class__(self.write(properties=[], format=1))
+            new_node = self.__class__(self.write(properties=[], format=1), format=1)
         elif method == "deepcopy":
             parent = self.up
             self.up = None

--- a/ete4/coretype/tree.pyx
+++ b/ete4/coretype/tree.pyx
@@ -53,8 +53,12 @@ from .. import utils
 
 # the following imports are necessary to set fixed styles and faces
 # try:
-from ..treeview.main import NodeStyle
-from ..treeview.faces import Face
+try: 
+    from ..treeview.main import NodeStyle
+    from ..treeview.faces import Face
+except ImportError: 
+    pass # Treeview is now an optional dependency
+
 from ete4.smartview import Face as smartFace
 from ete4.smartview.ete.face_positions import FACE_POSITIONS, _FaceAreas, get_FaceAreas
 # except ImportError:

--- a/ete4/parser/newick.pyx
+++ b/ete4/parser/newick.pyx
@@ -36,373 +36,476 @@
 #
 #
 # #END_LICENSE#############################################################
-""" Jordi's newick parser """
+from __future__ import absolute_import
+from __future__ import print_function
+import re
 import os
-from re import sub
+import six
+from six.moves import map
 
-from ete4 import Tree
+__all__ = ["read_newick", "write_newick", "print_supported_formats"]
 
+ITERABLE_TYPES = set([list, set, tuple, frozenset])
+
+# Regular expressions used for reading newick format
+_ILEGAL_NEWICK_CHARS = ":;(),\[\]\t\n\r="
+_NON_PRINTABLE_CHARS_RE = "[\x00-\x1f]+"
+
+_NHX_RE = "\[&&NHX:[^\]]*\]"
+_FLOAT_RE = "\s*[+-]?\d+\.?\d*(?:[eE][-+]?\d+)?\s*"
+#_FLOAT_RE = "[+-]?\d+\.?\d*"
+#_NAME_RE = "[^():,;\[\]]+"
+_NAME_RE = "[^():,;]+?"
+
+# thanks to: http://stackoverflow.com/a/29452781/1006828
+_QUOTED_TEXT_RE = r"""((?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*'))"""
+#_QUOTED_TEXT_RE = r"""["'](?:(?<=")[^"\\]*(?s:\\.[^"\\]*)*"|(?<=')[^'\\]*(?s:\\.[^'\\]*)*')""]"]"""
+#_QUOTED_TEXT_RE = r"""(?=["'])(?:"[^"\\]*(?:\\[\s\S][^"\\]*)*"|'[^'\\]*(?:\\[\s\S][^'\\]*)*')]"]")"]"""
+
+_QUOTED_TEXT_PREFIX='ete3_quotref_'
+
+DEFAULT_DIST = 1.0
+DEFAULT_NAME = ''
+DEFAULT_SUPPORT = 1.0
+FLOAT_FORMATTER = "%0.6g"
+#DIST_FORMATTER = ":"+FLOAT_FORMATTER
+NAME_FORMATTER = "%s"
+
+def set_float_format(formatter):
+    ''' Set the conversion format used to represent float distances and support
+    values in the newick representation of trees.
+
+    For example, use set_float_format('%0.32f') to specify 32 decimal numbers
+    when exporting node distances and bootstrap values.
+
+    Scientific notation (%e) or any other custom format is allowed. The
+    formatter string should not contain any character that may break newick
+    structure (i.e.: ":;,()")
+
+    '''
+    global FLOAT_FORMATTER
+    FLOAT_FORMATTER = formatter
+    #DIST_FORMATTER = ":"+FLOAT_FORMATTER
+
+# Allowed formats. This table is used to read and write newick using
+# different convenctions. You can also add your own formats in an easy way.
+#
+#
+# FORMAT: [[LeafAttr1, LeafAttr1Type, Strict?], [LeafAttr2, LeafAttr2Type, Strict?],\
+#    [InternalAttr1, InternalAttr1Type, Strict?], [InternalAttr2, InternalAttr2Type, Strict?]]
+#
+# Attributes are placed in the newick as follows:
+#
+# .... ,LeafAttr1:LeafAttr2)InternalAttr1:InternalAttr2 ...
+#
+#
+#           /-A
+# -NoName--|
+#          |          /-B
+#           \C-------|
+#                    |          /-D
+#                     \E-------|
+#                               \-G
+#
+# Format 0 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)1.000000:0.642905)1.000000:0.567737);
+# Format 1 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)E:0.642905)C:0.567737);
+# Format 2 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)1.000000:0.642905)1.000000:0.567737);
+# Format 3 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)E:0.642905)C:0.567737);
+# Format 4 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)));
+# Format 5 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729):0.642905):0.567737);
+# Format 6 = (A:0.350596,(B:0.728431,(D:0.609498,G:0.125729)E)C);
+# Format 7 = (A,(B,(D,G)E)C);
+# Format 8 = (A,(B,(D,G)));
+# Format 9 = (,(,(,)));
+
+NW_FORMAT = {
+  0: [['name', str, True],  ["dist", float, True],    ['support', float, True],   ["dist", float, True]], # Flexible with support
+  1: [['name', str, True],  ["dist", float, True],    ['name', str, True],      ["dist", float, True]], # Flexible with internal node names
+  2: [['name', str, False], ["dist", float, False],   ['support', float, False],  ["dist", float, False]],# Strict with support values
+  3: [['name', str, False], ["dist", float, False],   ['name', str, False],     ["dist", float, False]], # Strict with internal node names
+  4: [['name', str, False], ["dist", float, False],   [None, None, False],        [None, None, False]],
+  5: [['name', str, False], ["dist", float, False],   [None, None, False],        ["dist", float, False]],
+  6: [['name', str, False], [None, None, False],      [None, None, False],        ["dist", float, False]],
+  7: [['name', str, False], ["dist", float, False],   ["name", str, False],       [None, None, False]],
+  8: [['name', str, False], [None, None, False],      ["name", str, False],       [None, None, False]],
+  9: [['name', str, False], [None, None, False],      [None, None, False],        [None, None, False]], # Only topology with node names
+  100: [[None, None, False],  [None, None, False],      [None, None, False],        [None, None, False]] # Only Topology
+}
+
+
+def format_node(node, node_type, format, dist_formatter=None,
+                support_formatter=None, name_formatter=None,
+                quoted_names=False):
+    if dist_formatter is None: dist_formatter = FLOAT_FORMATTER
+    if support_formatter is None: support_formatter = FLOAT_FORMATTER
+    if name_formatter is None: name_formatter = NAME_FORMATTER
+
+    if node_type == "leaf":
+        container1 = NW_FORMAT[format][0][0] # name
+        container2 = NW_FORMAT[format][1][0] # dists
+        converterFn1 = NW_FORMAT[format][0][1]
+        converterFn2 = NW_FORMAT[format][1][1]
+        flexible1 = NW_FORMAT[format][0][2]
+    else:
+        container1 = NW_FORMAT[format][2][0] #support/name
+        container2 = NW_FORMAT[format][3][0] #dist
+        converterFn1 = NW_FORMAT[format][2][1]
+        converterFn2 = NW_FORMAT[format][3][1]
+        flexible1 = NW_FORMAT[format][2][2]
+
+    if converterFn1 == str:
+        try:
+            if not quoted_names:
+                FIRST_PART = re.sub("["+_ILEGAL_NEWICK_CHARS+"]", "_", \
+                                    str(getattr(node, container1)))
+            else:
+                FIRST_PART = str(getattr(node, container1))
+            if not FIRST_PART and container1 == 'name' and not flexible1:
+                FIRST_PART = "NoName"
+
+        except (AttributeError, TypeError):
+            FIRST_PART = "?"
+
+        FIRST_PART = name_formatter %FIRST_PART
+        if quoted_names:
+            #FIRST_PART = '"%s"' %FIRST_PART.decode('string_escape').replace('"', '\\"')
+            FIRST_PART = '"%s"' %FIRST_PART
+
+    elif converterFn1 is None:
+        FIRST_PART = ""
+    else:
+        try:
+            FIRST_PART = support_formatter %(converterFn2(getattr(node, container1)))
+        except (ValueError, TypeError):
+            FIRST_PART = "?"
+
+    if converterFn2 == str:
+        try:
+            SECOND_PART = ":"+re.sub("["+_ILEGAL_NEWICK_CHARS+"]", "_", \
+                                  str(getattr(node, container2)))
+        except (ValueError, TypeError):
+            SECOND_PART = ":?"
+    elif converterFn2 is None:
+        SECOND_PART = ""
+    else:
+        try:
+            #SECOND_PART = ":%0.6f" %(converterFn2(getattr(node, container2)))
+            SECOND_PART = ":%s" %(dist_formatter %(converterFn2(getattr(node, container2))))
+        except (ValueError, TypeError):
+            SECOND_PART = ":?"
+
+    return "%s%s" %(FIRST_PART, SECOND_PART)
+
+
+def print_supported_formats():
+    from ..coretype.tree import TreeNode
+    t = TreeNode()
+    t.populate(4, "ABCDEFGHI")
+    print(t)
+    for f in NW_FORMAT:
+        print("Format", f,"=", write_newick(t, properties=[], format=f))
 
 class NewickError(Exception):
     """Exception class designed for NewickIO errors."""
     def __init__(self, value):
         if value is None:
             value = ''
-        value += "\nYou may want to check the input Newick format."
+        value += "\nYou may want to check other newick loading flags like 'format' or 'quoted_node_names'."
         Exception.__init__(self, value)
 
-DEFAULT_FLOAT_FORMATTER = "%0.6g"
-DEFAULT_NAME_FORMATTER = "%s"
-
-FLOAT_FORMATTER = DEFAULT_FLOAT_FORMATTER
-DIST_FORMATTER = FLOAT_FORMATTER
-SUPPORT_FORMATTER = FLOAT_FORMATTER
-NAME_FORMATTER = DEFAULT_NAME_FORMATTER
-
-_ILLEGAL_NEWICK_CHARS = ":;(),\[\]\t\n\r="
-NW_FORMAT = {
-  #       leaf name                 leaf dist             internal support/name          internal dist
-  0: [['name', str, True],    ["dist", float, True],     ['support', float, True],   ["dist", float, True]],  # Flexible with support
-  1: [['name', str, True],    ["dist", float, True],     ['name', str, True],        ["dist", float, True]],  # Flexible with internal node names
-  2: [['name', str, False],   ["dist", float, False],    ['support', float, False],  ["dist", float, False]], # Strict with support values
-  3: [['name', str, False],   ["dist", float, False],    ['name', str, False],       ["dist", float, False]], # Strict with internal node names
-  4: [['name', str, False],   ["dist", float, False],    [None, None, False],        [None, None, False]],
-  5: [['name', str, False],   ["dist", float, False],    [None, None, False],        ["dist", float, False]],
-  6: [['name', str, False],   [None, None, False],       [None, None, False],        ["dist", float, False]],
-  7: [['name', str, False],   ["dist", float, False],    ["name", str, False],       [None, None, False]],    # all names
-  8: [['name', str, False],   [None, None, False],       ["name", str, False],       [None, None, False]],    # leaf names
-  9: [['name', str, False],   [None, None, False],       [None, None, False],        [None, None, False]],    # Only topology with node names
-  100: [[None, None, False],  [None, None, False],       [None, None, False],        [None, None, False]]     # Only Topology
-}
-
-
-def set_formatters(float_formatter=None, dist_formatter=None,
-                   support_formatter=None, name_formatter=None):
-    ''' Set the conversion format used to represent float distances and support
-    values in the newick representation of trees.
-    For example, use set_float_format('%0.32f') to specify 32 decimal numbers
-    when exporting node distances and bootstrap values.
-    Scientific notation (%e) or any other custom format is allowed. The
-    formatter string should not contain any character that may break newick
-    structure (i.e.: ":;,()")
-    '''
-    if float_formatter:
-        global FLOAT_FORMATTER
-        FLOAT_FORMATTER = float_formatter
-
-    global DIST_FORMATTER, SUPPORT_FORMATTER, NAME_FORMATTER
-    DIST_FORMATTER = dist_formatter or FLOAT_FORMATTER
-    SUPPORT_FORMATTER = support_formatter or FLOAT_FORMATTER
-    NAME_FORMATTER = name_formatter or DEFAULT_NAME_FORMATTER
-
-
-def get_newick_txt(newick):
-    # try to determine whether the file exists.
-    # For very large trees, if newick contains the content of the tree,
-    # rather than a file name, this may fail, at least on Windows, 
-    # because the os fails to stat the file content, deeming it
-    # too long for testing with os.path.exists.  
-    # This raises a ValueError with description
-    # "stat: path too long for Windows".  
-    # This is described in issue #258
-    try:
-        file_exists = os.path.exists(newick)
-    except ValueError:      # failed to stat
-        file_exists = False
-
-    # if newick refers to a file, read it from file
-    # otherwise, regard it as a Newick content string.
-    if file_exists:
-        if newick.endswith('.gz'):
-            import gzip
-            with gzip.open(newick) as INPUT:
-                nw = INPUT.read()
-        else:
-            with open(newick) as INPUT:
-                nw = INPUT.read()
-    else:
-        nw = newick
-    return str(nw).strip()
-
-
-def read_newick(nw, root_node=None):
+def read_newick(newick, root_node=None, format=0, quoted_names=False):
     """ Reads a newick tree from either a string or a file, and returns
     an ETE tree structure.
+
     A previously existent node object can be passed as the root of the
     tree, which means that all its new children will belong to the same
-    class as the root. This allows to work with custom TreeNode
-    objects.
+    class as the root(This allows to work with custom TreeNode
+    objects).
+
     You can also take advantage from this behaviour to concatenate
     several tree structures.
     """
-    # Retrieve file content nw is an existant file name
-    newick = get_newick_txt(nw)
-    t = root_node or Tree()
-    if newick == '' or newick[0] != '(':
-        # Get content from incomplete newick string
-        fill_node_content(t, newick)
-    else:
-        # Parse complete newick
-        read_newick_from_string(newick, t)
-    return t
 
+    if root_node is None:
+        from ..coretype.tree import TreeNode
+        root_node = TreeNode()
 
-def read_newick_from_string(tree_text, root_node):
-    "Return tree from its newick representation"
-    if not tree_text.endswith(';'):
-        raise NewickError('text ends with no ";"')
+    if isinstance(newick, six.string_types):
 
-    if tree_text[0] == '(':
-        nodes, pos = read_nodes(tree_text, root_node.__class__, 0)
-    else:
-        nodes, pos = [], 0
-
-    content, pos = read_content(tree_text, pos)
-    if pos != len(tree_text) - 1:
-        raise NewickError(f'root node ends at position {pos}, before tree ends')
-
-    t = root_node
-    fill_node_content(t, content)
-    t.add_children(nodes)
-
-    return t
-
-
-def read_nodes(nodes_text, NewNode, int pos=0):
-    "Return a list of nodes and the position in the text where they end"
-    # nodes_text looks like '(a,b,c)', where any element can be a list of nodes
-    if nodes_text[pos] != '(':
-        raise NewickError('nodes text starts with no "("')
-
-    nodes = []
-    while pos < len(nodes_text) and nodes_text[pos] != ')':
-        pos += 1
-        if pos >= len(nodes_text):
-            raise NewickError('nodes text ends missing a matching ")"')
-
-        pos = skip_spaces_and_comments(nodes_text, pos)
-
-        if nodes_text[pos] == '(':
-            children, pos = read_nodes(nodes_text, NewNode, pos)
-        else:
-            children = []
-
-        content, pos = read_content(nodes_text, pos)
-
-        t = NewNode(content)
-        t.add_children(children)
-        nodes.append(t)
-
-    return nodes, pos+1
-
-
-def fill_node_content(node, newick, children=None):
-    """Fill TreeNode with 'content' information: a tuple
-    consisting of name, dist and properties. 
-    Such information is extracted from an incomplete newick text field
-    In addition, already computed children may be added to the TreeNode object
-    """
-    content = get_content_fields(newick.rstrip(';'))
-    name, dist, properties = content
-    node.name = name
-    node.dist = dist
-    # Avoid removing preexisting properties
-    # while overriding default values
-    node.props = { **node.props, **properties }
-    
-    if children:
-        node.add_children(children)
-
-    return node
-
-
-def find_bracket(text, pos):
-    pos_list = text.find('[', pos)
-    pos_end = text.find(']', pos)
-    while pos_list < pos_end:
-        pos_list = text.find('[', pos_end+1)
-        pos_end = text.find(']', pos_end+1)
-    return pos_end
-
-
-def skip_spaces_and_comments(text, int pos):
-    "Return position in text after pos and after all whitespaces and comments"
-    while pos < len(text) and text[pos] in ' \t\r\n[':
-        if text[pos] == '[':
-            if text[pos+1] == '&':  # special annotation
-                return pos
-            else:
-                pos = find_bracket(text, pos+1)  # skip comment
-        pos += 1  # skip whitespace and comment endings
-    return pos
-
-
-def read_content(str text, int pos, endings=',);'):
-    "Return content starting at position pos in the text, and where it ends"
-    start = pos
-    if pos < len(text) and text[pos] == "'":
-        _, pos = read_quoted_name(text, pos)
-    keep_reading = []
-    while pos < len(text) and not (len(keep_reading) == 0 and text[pos] in endings):
-        if text[pos] == '[':
-            keep_reading.append(1)
-        elif keep_reading and text[pos] == ']':
-            keep_reading.pop()
-        pos += 1
-    return text[start:pos], pos
-
-
-def read_quoted_name(str text, int pos):
-    "Return quoted name and the position where it ends"
-    if pos >= len(text) or text[pos] not in ("'", '"'):
-        raise NewickError(f'text at position {pos} does not start with "\'"\
-                            nor "\"')
-
-    pos += 1
-    start = pos
-    while pos < len(text):
-        if text[pos] in ("'", '"'):
-            # Newick format escapes ' as ''
-            if pos+1 >= len(text) or text[pos+1] != "'":
-                return text[start:pos].replace("''", "'"), pos
-            pos += 2
-        else:
-            pos += 1
-
-    raise NewickError(f'unfinished quoted name: {text[start:]}')
-
-
-def get_content_fields(content):
-    """Return name, dist, properties from the content (as a newick) of a node
-
-    Example:
-      'abc:123[&&NHX:x=foo:y=bar]' -> ('abc', 123, {'x': 'foo', 'y': 'bar'})
-    """
-    cdef double dist
-    if content.startswith(("'", '"')):
-        name, pos = read_quoted_name(content, 0)
-        pos = skip_spaces_and_comments(content, pos+1)
-    else:
-        name, pos = read_content(content, 0, endings=':[')
-
-    if pos < len(content) and content[pos] == ':':
-        pos = skip_spaces_and_comments(content, pos+1)
-        dist_txt, pos = read_content(content, pos, endings='[ ')
+        # try to determine whether the file exists.
+        # For very large trees, if newick contains the content of the tree, rather than a file name,
+        # this may fail, at least on Windows, because the os fails to stat the file content, deeming it
+        # too long for testing with os.path.exists.  This raises a ValueError with description
+        # "stat: path too long for Windows".  This is described in issue #258
         try:
-            dist = float(dist_txt)
-        except ValueError:
-            raise NewickError('invalid number %r in %r' % (dist_txt, content))
-    else:
-        dist = -1
+            file_exists = os.path.exists(newick)
+        except ValueError:      # failed to stat
+            file_exists = False
 
-    if pos < len(content) and content[pos] == '[':
-        pos_end = find_bracket(content, pos)
-        properties = get_properties(content[pos+1:pos_end])
-    elif pos >= len(content):
-        properties = {}
-    else:
-        raise NewickError('malformed content: %r' % content)
-
-    return name, dist, properties
-
-
-def get_properties(text):
-    """Return a dict with the properties extracted from the text in NHX format
-
-    Example: '&&NHX:x=foo:y=bar' -> {'x': 'foo', 'y': 'bar'}
-    """
-    try:
-        assert text.startswith('&&NHX:'), 'unknown annotation (not "&&NHX")'
-        return dict(pair.split('=') for pair in text[len('&&NHX:'):].split(':'))
-    except (AssertionError, ValueError) as e:
-        raise NewickError('invalid NHX format (%s) in text %r' % (e, text))
-
-
-def content_repr(node, format=0, properties=[], quoted_names=False):
-    "Return content of a node as represented in specified newick format"
-    # Empty list includes all properties
-    props = [p for p in node.props.keys() if not p.startswith("_")]\
-            if properties == [] else list(properties or [])
-
-    if node.is_leaf():
-        name = NW_FORMAT[format][0][0]
-        dist = NW_FORMAT[format][1][0]
-        name_type = NW_FORMAT[format][0][1]
-        dist_type = NW_FORMAT[format][1][1]
-        flexible = NW_FORMAT[format][0][2]
-    else:
-        name = NW_FORMAT[format][2][0]
-        dist = NW_FORMAT[format][3][0]
-        name_type = NW_FORMAT[format][2][1]
-        dist_type = NW_FORMAT[format][3][1]
-        flexible = NW_FORMAT[format][2][2]
-
-    # NAME/SUPPORT FORMATTING
-    name_str = ''
-    support_str = ''
-    if name_type == str:
-        if node.name:
-            name_str = f'{NAME_FORMATTER}' % str(node.name)
-        elif not flexible:
-            name_str = f'{NAME_FORMATTER}' % 'NoName'
-
-        if 'name' in props:
-            props.remove('name')
-
-        # Quote name or remove newick-illegal characters
-        if quoted_names:
-            # TO CONSIDER: use quote() instead of quoted_names argument
-            name_str = "'" + name_str + "'"
+        # if newick refers to a file, read it from file; otherwise, regard it as a Newick content string.
+        if file_exists:
+            if newick.endswith('.gz'):
+                import gzip
+                with gzip.open(newick) as INPUT:
+                    nw = INPUT.read()
+            else:
+                with open(newick) as INPUT:
+                    nw = INPUT.read()
         else:
-            name_str = sub(f'[{_ILLEGAL_NEWICK_CHARS}]', '_', name_str)
-
-    elif name_type == float:  # support value
-        support_str = f'{SUPPORT_FORMATTER}' % float(node.support)
-        # Do not write redundant information
-        if 'support' in props:
-            props.remove('support')
-    else:  # name_type == None
-        name_str = ''
-
-    # DIST FORMATTING
-    dist_str = f':{DIST_FORMATTER}' % float(node.dist) \
-            if (node.dist >= 0 and dist_type != None) else ''
-
-    if 'dist' in props and dist_type != None:
-        props.remove('dist')
-
-    # PROPERTIES FORMATTING
-    pairs_str = ':'.join('%s=%s' % (k, node.props.get(k)) 
-                                    for k in props
-                                    if node.props.get(k))
-    props_str = f'[&&NHX:{pairs_str}]' if pairs_str else ''
-
-    return (name_str or support_str) + dist_str + props_str
+            nw = newick
 
 
-def quote(name, escaped_chars=" \t\r\n()[]':;,"):
-    "Return the name quoted if it has any characters that need escaping"
-    if any(c in name for c in escaped_chars):
-        return "'%s'" % name.replace("'", "''")  # ' escapes to '' in newicks
+        matcher = compile_matchers(format)
+        nw = nw.strip()
+        if not nw.startswith('(') and nw.endswith(';'):
+            #return _read_node_data(nw[:-1], root_node, "single", matcher, format)
+            return _read_newick_from_string(nw, root_node, matcher, format, quoted_names)
+        elif not nw.startswith('(') or not nw.endswith(';'):
+            raise NewickError('Unexisting tree file or Malformed newick tree structure.')
+        else:
+            return _read_newick_from_string(nw, root_node, matcher, format, quoted_names)
+
     else:
-        return name
+        raise NewickError("'newick' argument must be either a filename or a newick string.")
+
+def _read_newick_from_string(nw, root_node, matcher, formatcode, quoted_names):
+    """ Reads a newick string in the New Hampshire format. """
+
+    if quoted_names:
+        # Quoted text is mapped to references
+        quoted_map = {}
+        unquoted_nw = ''
+        counter = 0
+        for token in re.split(_QUOTED_TEXT_RE, nw):
+            counter += 1
+            if counter % 2 == 1 : # normal newick tree structure data
+                unquoted_nw += token
+            else: # quoted text, add to dictionary and replace with reference
+                quoted_ref_id= _QUOTED_TEXT_PREFIX + str(int(counter/2))
+                unquoted_nw += quoted_ref_id
+                quoted_map[quoted_ref_id]=token[1:-1]  # without the quotes
+        nw = unquoted_nw
+
+    if not nw.startswith('(') and nw.endswith(';'):
+        _read_node_data(nw[:-1], root_node, "single", matcher, format)
+        if quoted_names:
+            if root_node.name.startswith(_QUOTED_TEXT_PREFIX):
+                root_node.name = quoted_map[root_node.name]
+        return root_node
+
+    if nw.count('(') != nw.count(')'):
+        raise NewickError('Parentheses do not match. Broken tree structure?')
+
+    # white spaces and separators are removed
+    nw = re.sub("[\n\r\t]+", "", nw)
+
+    current_parent = None
+    # Each chunk represents the content of a parent node, and it could contain
+    # leaves and closing parentheses.
+    # We may find:
+    # leaf, ..., leaf,
+    # leaf, ..., leaf))),
+    # leaf)), leaf, leaf))
+    # leaf))
+    # ) only if formatcode == 100
+
+    for chunk in nw.split("(")[1:]:
+        # If no node has been created so far, this is the root, so use the node.
+        current_parent = root_node if current_parent is None else current_parent.add_child()
+
+        subchunks = [ch.strip() for ch in chunk.split(",")]
+        # We should expect that the chunk finished with a comma (if next chunk
+        # is an internal sister node) or a subchunk containing closing parenthesis until the end of the tree.
+        #[leaf, leaf, '']
+        #[leaf, leaf, ')))', leaf, leaf, '']
+        #[leaf, leaf, ')))', leaf, leaf, '']
+        #[leaf, leaf, ')))', leaf), leaf, 'leaf);']
+        if subchunks[-1] != '' and not subchunks[-1].endswith(';'):
+            raise NewickError('Broken newick structure at: %s' %chunk)
+
+        # lets process the subchunks. Every closing parenthesis will close a
+        # node and go up one level.
+        for i, leaf in enumerate(subchunks):
+            if leaf.strip() == '' and i == len(subchunks) - 1:
+                continue # "blah blah ,( blah blah"
+            closing_nodes = leaf.split(")")
+
+            # first part after splitting by ) always contain leaf info
+            _read_node_data(closing_nodes[0], current_parent, "leaf", matcher, formatcode)
+
+            # next contain closing nodes and data about the internal nodes.
+            if len(closing_nodes)>1:
+                for closing_internal in closing_nodes[1:]:
+                    closing_internal =  closing_internal.rstrip(";")
+                    # read internal node data and go up one level
+                    _read_node_data(closing_internal, current_parent, "internal", matcher, formatcode)
+                    current_parent = current_parent.up
+
+    # references in node names are replaced with quoted text before returning
+    if quoted_names:
+        for node in root_node.traverse():
+            if node.name.startswith(_QUOTED_TEXT_PREFIX):
+                node.name = quoted_map[node.name]
+
+    return root_node
+
+def _parse_extra_features(node, NHX_string):
+    """ Reads node's extra data form its NHX string. NHX uses this
+    format:  [&&NHX:prop1=value1:prop2=value2] """
+    NHX_string = NHX_string.replace("[&&NHX:", "")
+    NHX_string = NHX_string.replace("]", "")
+    for field in NHX_string.split(":"):
+        try:
+            pname, pvalue = field.split("=")
+        except ValueError as e:
+            raise NewickError('Invalid NHX format %s' %field)
+        node.add_prop(pname, pvalue)
+
+def compile_matchers(formatcode):
+    matchers = {}
+    for node_type in ["leaf", "single", "internal"]:
+        if node_type == "leaf" or node_type == "single":
+            container1 = NW_FORMAT[formatcode][0][0]
+            container2 = NW_FORMAT[formatcode][1][0]
+            converterFn1 = NW_FORMAT[formatcode][0][1]
+            converterFn2 = NW_FORMAT[formatcode][1][1]
+            flexible1 = NW_FORMAT[formatcode][0][2]
+            flexible2 = NW_FORMAT[formatcode][1][2]
+        else:
+            container1 = NW_FORMAT[formatcode][2][0]
+            container2 = NW_FORMAT[formatcode][3][0]
+            converterFn1 = NW_FORMAT[formatcode][2][1]
+            converterFn2 = NW_FORMAT[formatcode][3][1]
+            flexible1 = NW_FORMAT[formatcode][2][2]
+            flexible2 = NW_FORMAT[formatcode][3][2]
+
+        if converterFn1 == str:
+            FIRST_MATCH = "("+_NAME_RE+")"
+        elif converterFn1 == float:
+            FIRST_MATCH = "("+_FLOAT_RE+")"
+        elif converterFn1 is None:
+            FIRST_MATCH = '()'
+
+        if converterFn2 == str:
+            SECOND_MATCH = "(:"+_NAME_RE+")"
+        elif converterFn2 == float:
+            SECOND_MATCH = "(:"+_FLOAT_RE+")"
+        elif converterFn2 is None:
+            SECOND_MATCH = '()'
+
+        if flexible1 and node_type != 'leaf':
+            FIRST_MATCH += "?"
+        if flexible2:
+            SECOND_MATCH += "?"
 
 
-def write_newick(tree, format=0, properties=[], quoted_names=False):
-    "Return newick representation from tree"
-    children_text = ','.join(write_newick(node, format, properties=properties,
-                                          quoted_names=quoted_names)\
-                       .rstrip(';') for node in tree.children)
-    content_text = content_repr(tree, format=format, properties=properties,
-                                quoted_names=quoted_names)
-    return (f'({children_text})' if tree.children else '') + content_text + ';'
+        matcher_str= '^\s*%s\s*%s\s*(%s)?\s*$' % (FIRST_MATCH, SECOND_MATCH, _NHX_RE)
+        compiled_matcher = re.compile(matcher_str)
+        matchers[node_type] = [container1, container2, converterFn1, converterFn2, compiled_matcher]
 
+    return matchers
 
-def print_supported_formats():
-    from ete4.smartview.ete.gardening import standardize
-    t = Tree()
-    t.populate(4, "ABCDEFGHI")
-    print(t)
-    for f in NW_FORMAT:
-        print(' '.join(["Format", str(f),"=", 
-            write_newick(t, format=f, properties=None, quoted_names=False)]))
+def _read_node_data(subnw, current_node, node_type, matcher, formatcode):
+    """ Reads a leaf node from a subpart of the original newick
+    tree """
+
+    if node_type == "leaf" or node_type == "single":
+        if node_type == "leaf":
+            node = current_node.add_child()
+        else:
+            node = current_node
+    else:
+        node = current_node
+
+    subnw = subnw.strip()
+
+    if not subnw and node_type == 'leaf' and formatcode != 100:
+        raise NewickError('Empty leaf node found')
+    elif not subnw:
+        return
+
+    container1, container2, converterFn1, converterFn2, compiled_matcher = matcher[node_type]
+    data = re.match(compiled_matcher, subnw)
+    if data:
+        data = data.groups()
+        # This prevents ignoring errors even in flexible nodes:
+        if subnw and data[0] is None and data[1] is None and data[2] is None:
+            raise NewickError("Unexpected newick format '%s'" %subnw)
+
+        if data[0] is not None and data[0] != '':
+            node.add_prop(container1, converterFn1(data[0].strip()))
+
+        if data[1] is not None and data[1] != '':
+            node.add_prop(container2, converterFn2(data[1][1:].strip()))
+
+        if data[2] is not None \
+                and data[2].startswith("[&&NHX"):
+            _parse_extra_features(node, data[2])
+    else:
+        raise NewickError("Unexpected newick format '%s' " %subnw[0:50])
+    return
+
+def write_newick(rootnode, properties=None, format=1, format_root_node=True,
+                 is_leaf_fn=None, dist_formatter=None, support_formatter=None,
+                 name_formatter=None, quoted_names=False):
+    """ Iteratively export a tree structure and returns its NHX
+    representation. """
+    newick = []
+    leaf = is_leaf_fn if is_leaf_fn else lambda n: not bool(n.children)
+    for postorder, node in rootnode.iter_prepostorder(is_leaf_fn=is_leaf_fn):
+        if postorder:
+            newick.append(")")
+            if node.up is not None or format_root_node:
+                newick.append(format_node(node, "internal", format,
+                                          dist_formatter=dist_formatter,
+                                          support_formatter=support_formatter,
+                                          name_formatter=name_formatter,
+                                          quoted_names=quoted_names))
+                newick.append(_get_features_string(node, properties))
+        else:
+            if node is not rootnode and node != node.up.children[0]:
+                newick.append(",")
+
+            if leaf(node):
+                newick.append(format_node(node, "leaf", format,
+                                          dist_formatter=dist_formatter,
+                                          support_formatter=support_formatter,
+                                          name_formatter=name_formatter,
+                                          quoted_names=quoted_names))
+                newick.append(_get_features_string(node, properties))
+            else:
+                newick.append("(")
+
+    newick.append(";")
+    return ''.join(newick)
+
+def _get_features_string(self, features=None):
+    """ Generates the extended newick string NHX with extra data about
+    a node. """
+    string = ""
+    if features is None:
+        features = []
+    elif features == []:
+        features = sorted(self._properties.keys())
+
+    for pr in features:
+        if pr in self._properties:
+            raw = self._properties[pr]
+            if type(raw) in ITERABLE_TYPES:
+                raw = '|'.join(map(str, raw))
+            elif type(raw) == dict:
+                raw = '|'.join(map(lambda x,y: "%s-%s" %(x, y), six.iteritems(raw)))
+            elif type(raw) == str:
+                pass
+            else:
+                raw = str(raw)
+
+            value = re.sub("["+_ILEGAL_NEWICK_CHARS+"]", "_", \
+                             raw)
+            if string != "":
+                string +=":"
+            string +="%s=%s"  %(pr, str(value))
+    if string != "":
+        string = "[&&NHX:"+string+"]"
+
+    return string

--- a/ete4/smartview/ete/layouts/phylocloud_egg5_layouts.py
+++ b/ete4/smartview/ete/layouts/phylocloud_egg5_layouts.py
@@ -1,4 +1,3 @@
-from ete4.treeview.main import NodeStyle
 from ete4.smartview.ete.faces import RectFace, TextFace
 from collections import OrderedDict
 

--- a/ete4/smartview/gui/server.py
+++ b/ete4/smartview/gui/server.py
@@ -224,7 +224,8 @@ class Trees(Resource):
         if rule.startswith('/trees/<string:tree_id>'):
             tid, subtree = get_tid(tree_id)
             t = load_tree(tid)
-            app.trees[int(tid)].timer = time()
+            tree = app.trees[int(tid)]
+            tree.timer = time()
 
         if rule == '/trees/<string:tree_id>':
             modify_tree_fields(tree_id)
@@ -238,7 +239,8 @@ class Trees(Resource):
             if subtree:
                 raise InvalidUsage('operation not allowed with subtree')
             node_id = request.json
-            app.trees[int(tid)].tree = gdn.root_at(gdn.get_node(t, node_id))
+            tree.tree.set_outgroup(gdn.get_node(t, node_id))
+            # app.trees[int(tid)].tree = gdn.root_at(gdn.get_node(t, node_id))
             return {'message': 'ok'}
         elif rule == '/trees/<string:tree_id>/move':
             try:

--- a/ete4/test/test_api.py
+++ b/ete4/test/test_api.py
@@ -14,7 +14,7 @@ from .test_clustertree import *
 from .test_evol import *
 #from .test_xml_parsers import *
 
-from .test_treeview.test_all_treeview import *
+#from .test_treeview.test_all_treeview import *
 
 def run():
     unittest.main()


### PR DESCRIPTION
- makes original newick parser compatible with new Tree instance 
- test_tree.py is now passing 
- goes back to original set_outgroup function for backwards compatibility