### PR TITLE
Reorganize control panel

### DIFF
--- a/ete4/smartview/gui/static/gui.css
+++ b/ete4/smartview/gui/static/gui.css
@@ -331,3 +331,37 @@ button.tp-tbiv_b {
     --tp-button-background-color: #d6d6d6;
     --tp-button-background-color-hover: #ccc;
 }
+
+
+
+/*Tooltip*/
+.tooltip {
+  display: none;
+  position: absolute;
+  width: 160px;
+  /*background-color: #d6d6d6;*/
+  background-color: #eaeaea;
+  color: black;
+  font-family:sans-serif;
+  font-size: 12px;
+  padding: 5px 10px;
+  margin-top: 20px;
+  margin-left: -45px;
+  border-radius: 2px;
+  border: solid 1px lightgray;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  transition: opacity 0.3s;
+  pointer-events: all;
+}
+
+.tooltip::after {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent lightgray transparent;
+}

--- a/ete4/smartview/gui/static/gui.css
+++ b/ete4/smartview/gui/static/gui.css
@@ -346,7 +346,7 @@ button.tp-tbiv_b {
   font-size: 12px;
   padding: 5px 10px;
   margin-top: 20px;
-  margin-left: -45px;
+  margin-left: -55px;
   border-radius: 2px;
   border: solid 1px lightgray;
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);

--- a/ete4/smartview/gui/static/gui.html
+++ b/ete4/smartview/gui/static/gui.html
@@ -41,5 +41,6 @@
     <div id="div_minimap" class="minimap"><svg></svg></div>
     <div id="div_visible_rect" class="visible_rect"></div>
     <div id="tree_scale" class="tree_scale"><svg></svg></div>
+    <span id="tooltip" class="tooltip"></span>
   </body>
 </html>

--- a/ete4/smartview/gui/static/js/collapse.js
+++ b/ete4/smartview/gui/static/js/collapse.js
@@ -1,39 +1,25 @@
 // Functions related to manually collapsed nodes.
 
-import { view, menus } from "./gui.js";
+import { view } from "./gui.js";
 import { draw_tree } from "./draw.js";
 
 export { collapse_node, remove_collapsed };
 
 
 // Mark node as collapsed and show it in the corresponding menu.
-function collapse_node(name, node_id) {
+function collapse_node(node_id) {
     const id = node_id.toString();  // [1,0,1] -> "1,0,1"
 
     view.collapsed_ids[id] = {};
-
-    const fname = `${get_next_number()} - ` +
-        (name ? name.slice(0, 20) : "(unnamed)");
-
-    const folder = menus.collapsed.addFolder({ title: fname });
 
     const collapsed_node = view.collapsed_ids[id];
 
     collapsed_node.remove = function() {
         delete view.collapsed_ids[id];
-        folder.dispose();
         draw_tree();
     }
 
-    folder.addButton({ title: "remove" }).on("click", collapsed_node.remove)
-
     draw_tree();
-}
-
-function get_next_number() {
-    const names = menus.collapsed.children.map(c => c.title);
-    const numbers = names.map(x => Number(x.split(" - ", 1)[0]));
-    return Math.max(0, ...numbers) + 1;
 }
 
 

--- a/ete4/smartview/gui/static/js/contextmenu.js
+++ b/ete4/smartview/gui/static/js/contextmenu.js
@@ -66,9 +66,16 @@ async function add_node_options(box, name, properties, node_id) {
         }, `Open the NCBI Taxonomy Browser on this taxonomy ID: ${taxid}.`,
            "book", false);
     }
-    add_button("Collapse branch", () => collapse_node(name, node_id),
-               "Do not show nodes below the current one.",
-               "compress", false);
+
+    const collapsed_node = view.collapsed_ids[node_id];
+    if (collapsed_node)
+        add_button("Uncollapse branch", () => collapsed_node.remove(),
+                   "Show nodes below the current one.",
+                   "expand", false);
+    else
+        add_button("Collapse branch", () => collapse_node(node_id),
+                   "Do not show nodes below the current one.",
+                   "compress", false);
 
     if (view.active.nodes.find(n => n.id === String(node_id)))
         add_button("Unselect node", () => deactivate_node(node_id),

--- a/ete4/smartview/gui/static/js/contextmenu.js
+++ b/ete4/smartview/gui/static/js/contextmenu.js
@@ -1,6 +1,5 @@
 // Functions related to the context menu (right-click menu).
 
-import { api } from "./api.js";
 import { view, tree_command, on_tree_change, reset_view, sort, get_tid }
     from "./gui.js";
 import { draw_minimap } from "./minimap.js";
@@ -9,12 +8,13 @@ import { download_newick } from "./download.js";
 import { zoom_into_box } from "./zoom.js";
 import { collapse_node } from "./collapse.js";
 import { activate_node, deactivate_node } from "./active.js";
-import { select_node, unselect_node } from "./select.js";
 
 export { on_box_contextmenu };
 
 
 async function on_box_contextmenu(event, box, name, properties, node_id=[]) {
+
+    console.log(node_id)
     event.preventDefault();
 
     div_contextmenu.innerHTML = "";
@@ -78,22 +78,6 @@ async function add_node_options(box, name, properties, node_id) {
         add_button("Select node", () => activate_node(node_id, properties),
                    "Add current node from active selection.",
                    "hand-pointer", false);
-
-    //const tid = get_tid() + "," + node_id;
-    //const selections = await api(`/trees/${tid}/selections`);
-    //if (selections.selections.length)
-        //add_button("Unselect node", () => unselect_node(node_id),
-                   //"Remove current node from selection.",
-                   //"trash-alt", false);
-    //else
-        //add_button("Select node", () => {
-            //Swal.fire({
-                //input: "text",
-                //text: "Enter name to describe selection",
-                //inputValue: name || node_id.join(","),
-                //preConfirm: name => select_node(node_id, name)
-            //});
-        //}, "Select current node.", "hand-pointer", false);
 
     if ("hyperlink" in properties) {
         const [ label, url ] = properties["hyperlink"];

--- a/ete4/smartview/gui/static/js/drag.js
+++ b/ete4/smartview/gui/static/js/drag.js
@@ -41,7 +41,10 @@ function drag_stop() {
     }
 
     if (dragging.moved) {
-        draw_tree();
+        if (dragging.element == div_aligned)
+            draw_aligned();
+        else
+            draw_tree();
         dragging.moved = false;
     }
 
@@ -55,48 +58,49 @@ function drag_move(point) {
                       y: point.y - dragging.p_last.y};
     dragging.p_last = point;
 
-    if (dragging.element === div_aligned && dragging.from_grabber) {
-        view.aligned.pos += 100 * movement.x / div_tree.offsetWidth;
-        view.aligned.pos = Math.min(Math.max(view.aligned.pos, 1), 99);  // clip
-        div_aligned.style.width = `${100 - view.aligned.pos}%`;
-    }
-    else if (dragging.element) {
+    if (dragging.element) {
         dragging.moved = true;
-
-        const [scale_x, scale_y] = get_drag_scale();
-
-        let dx = point.x - dragging.p0.x,
-            dy = point.y - dragging.p0.y;
-
-        if (dragging.element === div_visible_rect) {
-            dx *= -view.zoom.x / view.minimap.zoom.x;
-            dy *= -view.zoom.y / view.minimap.zoom.y;
+        if (dragging.element === div_aligned && dragging.from_grabber) {
+            view.aligned.pos += 100 * movement.x / div_tree.offsetWidth;
+            view.aligned.pos = Math.min(Math.max(view.aligned.pos, 1), 99);  // clip
+            div_aligned.style.width = `${100 - view.aligned.pos}%`;
         }
-
-        if (dragging.element === div_aligned) {
-            view.aligned.x += scale_x * movement.x;
-
-            const toTranslate = [ 
-                //...div_aligned.children[0].children,
-                ...div_aligned_header.children[0].children,
-                ...div_aligned_footer.children[0].children,
-            ];
-            toTranslate.forEach(g =>
-                g.setAttribute("transform", `translate(${dx} 0)`));
-            // pixi canvas
-            //div_aligned.children[1].children[0].style.transform = `translate(${movement.x}px, 0)`;
-
-            draw_aligned(undefined, 2);
-        }
-
         else {
-            view.tl.x += scale_x * movement.x;
-            view.tl.y += scale_y * movement.y;
-            Array.from(div_tree.children[0].children).forEach(g =>
-                g.setAttribute("transform", `translate(${dx} ${dy})`));
+            const [scale_x, scale_y] = get_drag_scale();
 
-            if (view.minimap.show)
-                update_minimap_visible_rect();
+            let dx = point.x - dragging.p0.x,
+                dy = point.y - dragging.p0.y;
+
+            if (dragging.element === div_visible_rect) {
+                dx *= -view.zoom.x / view.minimap.zoom.x;
+                dy *= -view.zoom.y / view.minimap.zoom.y;
+            }
+
+            if (dragging.element === div_aligned) {
+                view.aligned.x += scale_x * movement.x;
+
+                const toTranslate = [ 
+                    //...div_aligned.children[0].children,
+                    ...div_aligned_header.children[0].children,
+                    ...div_aligned_footer.children[0].children,
+                ];
+                toTranslate.forEach(g =>
+                    g.setAttribute("transform", `translate(${dx} 0)`));
+                // pixi canvas
+                //div_aligned.children[1].children[0].style.transform = `translate(${movement.x}px, 0)`;
+
+                draw_aligned(undefined, 2);
+            }
+
+            else {
+                view.tl.x += scale_x * movement.x;
+                view.tl.y += scale_y * movement.y;
+                Array.from(div_tree.children[0].children).forEach(g =>
+                    g.setAttribute("transform", `translate(${dx} ${dy})`));
+
+                if (view.minimap.show)
+                    update_minimap_visible_rect();
+            }
         }
     }
 }

--- a/ete4/smartview/gui/static/js/drag.js
+++ b/ete4/smartview/gui/static/js/drag.js
@@ -102,7 +102,10 @@ function drag_move(point) {
                     update_minimap_visible_rect();
             }
         }
-    }
+
+        return 1
+    } else
+        return undefined
 }
 
 

--- a/ete4/smartview/gui/static/js/draw.js
+++ b/ete4/smartview/gui/static/js/draw.js
@@ -11,7 +11,7 @@ import { on_box_contextmenu } from "./contextmenu.js";
 import { api } from "./api.js";
 import { draw_pixi } from "./pixi.js";
 
-export { update, draw_tree, draw_tree_scale, draw_aligned, draw, get_class_name, cartesian_shifted };
+export { update, draw_tree, draw_tree_scale, draw_aligned, draw, get_class_name, cartesian_shifted, update_aligned_panel_display };
 
 
 // Update the view of all elements (gui, tree, minimap).
@@ -70,15 +70,7 @@ async function draw_tree() {
         const drawer_info = await api(`/drawers/${view.drawer.name}/${get_tid()}`);
         view.drawer.npanels = drawer_info.npanels; // type has already been set
 
-        // Toggle aligned panel
-        if (drawer_info.type === "rect" && drawer_info.npanels > 1) {
-            div_aligned.style.display = "initial";  // show aligned panel
-            const tree_px_width = view.zoom.x * (view.tree_size.width - view.tl.x);
-            view.aligned.pos = 100 * (tree_px_width + 200) / div_tree.offsetWidth;
-            view.aligned.pos = Math.min(Math.max(view.aligned.pos, 1), 99);  // clip
-            div_aligned.style.width = `${100 - view.aligned.pos}%`;
-        } else
-            div_aligned.style.display = "none";  // hide aligned panel
+        update_aligned_panel_display();
 
         if (view.drawer.npanels > 1) {
             align_timeout = setTimeout(async () => { 
@@ -257,6 +249,20 @@ function replace_svg(element) {
     replace_child(element, svg);
 }
 
+function update_aligned_panel_display() {
+    // Toggle aligned panel
+    if (view.drawer.type === "rect" && view.drawer.npanels > 1) {
+        div_aligned.style.display = "initial";  // show aligned panel
+
+        if (view.aligned.adjust_pos) {
+            const tree_px_width = view.zoom.x * (view.tree_size.width - view.tl.x);
+            view.aligned.pos = 100 * (tree_px_width + view.aligned.padding) / div_tree.offsetWidth;
+            view.aligned.pos = Math.min(Math.max(view.aligned.pos, 1), 99);  // clip
+            div_aligned.style.width = `${100 - view.aligned.pos}%`;
+        }
+    } else
+        div_aligned.style.display = "none";  // hide aligned panel
+}
 
 // Draw elements that belong to panels above 0.
 async function draw_aligned(params, npanels) {

--- a/ete4/smartview/gui/static/js/draw.js
+++ b/ete4/smartview/gui/static/js/draw.js
@@ -71,9 +71,13 @@ async function draw_tree() {
         view.drawer.npanels = drawer_info.npanels; // type has already been set
 
         // Toggle aligned panel
-        if (drawer_info.type === "rect" && drawer_info.npanels > 1)
+        if (drawer_info.type === "rect" && drawer_info.npanels > 1) {
             div_aligned.style.display = "initial";  // show aligned panel
-        else
+            const tree_px_width = view.zoom.x * (view.tree_size.width - view.tl.x);
+            view.aligned.pos = 100 * (tree_px_width + 200) / div_tree.offsetWidth;
+            view.aligned.pos = Math.min(Math.max(view.aligned.pos, 1), 99);  // clip
+            div_aligned.style.width = `${100 - view.aligned.pos}%`;
+        } else
             div_aligned.style.display = "none";  // hide aligned panel
 
         if (view.drawer.npanels > 1) {
@@ -81,7 +85,7 @@ async function draw_tree() {
                 if (!align_drawing)
                     await draw_aligned(params);
                 clearTimeout(align_timeout);
-            }, 70);
+            }, view.aligned.timeout);
         }
 
         if (view.drawer.type === "circ") {

--- a/ete4/smartview/gui/static/js/draw.js
+++ b/ete4/smartview/gui/static/js/draw.js
@@ -384,11 +384,8 @@ function create_item(g, item, tl, zoom) {
         b.addEventListener("mouseleave", _ =>
             on_box_mouseleave(node_id));
 
-        if (name.length > 0 || Object.entries(properties).length > 0) {
-            const text = (name ? name : "(unnamed)") + "\n" +
-            Object.entries(properties).map(x => x[0] + ": " + x[1]).join("\n");
-            b.appendChild(create_tooltip(text));
-        }
+        if (name.length > 0 || Object.entries(properties).length > 0)
+            b.appendChild(create_tooltip(name, properties))
 
         return b;
     }
@@ -426,8 +423,7 @@ function create_item(g, item, tl, zoom) {
 
         style_ellipse(circle, style); // same styling as ellipse
 
-        if (tooltip)
-            circle.appendChild(create_tooltip(tooltip));
+        circle.setAttribute("data-tooltip", tooltip);;
 
         return circle
     }
@@ -444,8 +440,7 @@ function create_item(g, item, tl, zoom) {
         
         style_ellipse(ellipse, style);
 
-        if (tooltip)
-            ellipse.appendChild(create_tooltip(tooltip));
+        ellipse.setAttribute("data-tooltip", tooltip);;
 
         return ellipse;
     }
@@ -466,8 +461,7 @@ function create_item(g, item, tl, zoom) {
 
         style_polygon(triangle, style);
 
-        if (tooltip)
-            triangle.appendChild(create_tooltip(tooltip));
+        triangle.setAttribute("data-tooltip", tooltip);;
 
         return triangle;
     }
@@ -486,10 +480,7 @@ function create_item(g, item, tl, zoom) {
 
         const rect = create_box(box, tl, zx, zy, type, style);
 
-        style_polygon(rect, style);
-
-        if (tooltip)
-            rect.appendChild(create_tooltip(tooltip));
+        rect.setAttribute("data-tooltip", tooltip);
 
         return rect;
     }
@@ -500,8 +491,7 @@ function create_item(g, item, tl, zoom) {
 
         style_polygon(rhombus, style);
 
-        if (tooltip)
-            rhombus.appendChild(create_tooltip(tooltip))
+        rhombus.setAttribute("data-tooltip", tooltip);
 
         return rhombus;
     }
@@ -512,8 +502,7 @@ function create_item(g, item, tl, zoom) {
 
         style_polygon(polygon, style);
 
-        if (tooltip)
-            polygon.appendChild(create_tooltip(tooltip))
+        polygon.setAttribute("data-tooltip", tooltip);
 
         return polygon;
     }
@@ -524,8 +513,7 @@ function create_item(g, item, tl, zoom) {
 
         style_polygon(slice, style);
 
-        if (tooltip)
-            slice.appendChild(create_tooltip(tooltip))
+        slice.setAttribute("data-tooltip", tooltip);
 
         return slice;
     }
@@ -710,12 +698,13 @@ function create_circ_outline(sbox, tl, z) {
 
 // Return an element that, appended to a svg element (normally a box), will
 // make it show a tooltip showing nicely the given name and properties.
-function create_tooltip(text) {
+function create_tooltip(name, properties) {
+    const text = (name ? name : "(unnamed)") + "\n" +
+        Object.entries(properties).map(x => x[0] + ": " + x[1]).join("\n");
     const title = create_svg_element("title", {});
     title.appendChild(document.createTextNode(text));
-    return title;
+    return title
 }
-
 
 function create_line(p1, p2, tl, zx, zy, type="", parent_of=[]) {
     const [x1, y1] = [zx * (p1[0] - tl.x), zy * (p1[1] - tl.y)],

--- a/ete4/smartview/gui/static/js/events.js
+++ b/ete4/smartview/gui/static/js/events.js
@@ -163,6 +163,32 @@ function on_mousedown(event) {
     // so the order in which to do the contains() tests matters.
 }
 
+function update_tooltip(event) {
+
+    function clear_timeout() {
+        if (view.tooltip.timeout) {
+            clearTimeout(view.tooltip.timeout);
+            view.tooltip.timeout = undefined;
+        }
+    }
+
+    if (tooltip.contains(event.target)) {
+        clear_timeout();
+        return
+    }
+
+    const style = tooltip.style;
+    const data = event.target.getAttribute("data-tooltip");
+    if (data) {
+        tooltip.innerHTML = data;
+        style.display = "block";
+        const bbox = event.target.getBoundingClientRect();
+        style.left = bbox.x + "px";
+        style.top = bbox.y + "px";
+        clear_timeout();
+    } else if (!view.tooltip.timeout)
+        view.tooltip.timeout = setTimeout(() => style.display = "none", 500);
+}
 
 // Mouse move -- move tree view if dragging, update position coordinates.
 function on_mousemove(event) {
@@ -171,6 +197,8 @@ function on_mousemove(event) {
     drag_move(point);
 
     [view.pos.cx, view.pos.cy] = coordinates(point);
+
+    update_tooltip(event);
 }
 
 

--- a/ete4/smartview/gui/static/js/gui.js
+++ b/ete4/smartview/gui/static/js/gui.js
@@ -30,7 +30,6 @@ const view = {
     tree: null,  // string with the current tree name
     tree_size: {width: 0, height: 0},
     ultrametric: false,
-    node_properties: [],  // existing in the current tree
     subtree: "",  // node id of the current subtree; looks like "0,1,0,0,1"
     sorting: {
         sort: () => sort(),
@@ -53,6 +52,7 @@ const view = {
     aligned: {
         x: -10,
         pos: 80,  // % of the screen width where the aligned panel starts
+        timeout: 100,  // ms to refresh
         zoom: false,
         max_zoom: undefined,
         adjust_zoom: true,
@@ -498,7 +498,7 @@ function get_url_view(x, y, w, h) {
 async function show_tree_info() {
     const info = await api(`/trees/${get_tid()}`);
 
-    const props = view.node_properties.map(p =>
+    const props = info.props.map(p =>
         `<tt>${escape_html(p)}</tt>`).join("<br>");
 
     const w = div_tree.offsetWidth / view.zoom.x,

--- a/ete4/smartview/gui/static/js/gui.js
+++ b/ete4/smartview/gui/static/js/gui.js
@@ -52,6 +52,8 @@ const view = {
     aligned: {
         x: -10,
         pos: 80,  // % of the screen width where the aligned panel starts
+        adjust_pos: true,
+        padding: 200,
         timeout: 100,  // ms to refresh
         zoom: false,
         max_zoom: undefined,

--- a/ete4/smartview/gui/static/js/gui.js
+++ b/ete4/smartview/gui/static/js/gui.js
@@ -49,6 +49,9 @@ const view = {
     current_property: "name",  // pre-selected property in the add label menu
     rmin: 0,
     angle: {min: -180, max: 180},
+    tooltip: {
+        timeout: undefined,
+    },
     aligned: {
         x: -10,
         pos: 80,  // % of the screen width where the aligned panel starts

--- a/ete4/smartview/gui/static/js/menu.js
+++ b/ete4/smartview/gui/static/js/menu.js
@@ -4,7 +4,7 @@ import { api } from "./api.js";
 import { view, menus, on_tree_change,
          on_drawer_change, show_minimap, get_tid } from "./gui.js";
 import { draw_minimap } from "./minimap.js";
-import { update, draw_tree_scale, draw_aligned } from "./draw.js";
+import { update, draw_tree_scale, draw_aligned, update_aligned_panel_display } from "./draw.js";
 import { add_folder_active } from "./active.js";
 
 export { init_menus, update_folder_layouts };
@@ -112,11 +112,11 @@ function create_menu_basic(menu, trees) {
 function create_menu_advanced(menu) {
     add_folder_info(menu);
 
+    add_folder_sort(menu);
+
     add_folder_view(menu);
 
     add_folder_circular(menu)
-
-    add_folder_sort(menu);
 
     add_folder_minimap(menu);
 
@@ -127,7 +127,7 @@ function create_menu_advanced(menu) {
 
 
 function add_folder_circular(menu) {
-    const folder_circ = menu.addFolder({ title: "Circular", expanded: false });
+    const folder_circ = menu.addFolder({ title: "Circular mode", expanded: false });
 
     function update_with_minimap() {
         draw_minimap();
@@ -148,8 +148,6 @@ function add_folder_circular(menu) {
 
 function create_menu_selection(menu) {
     // filled dynamically in collapsed.js and select.js
-    menus.collapsed = menu.addFolder({ title: "Collapsed", expanded: false }); 
-
     view.active.folder = menu.addFolder({ title: `Active ${view.active.nodes.length}` });
     add_folder_active();
 
@@ -428,4 +426,11 @@ function add_folder_aligned(menu) {
     folder_aligned.addInput(view.aligned, "pos", { label: "position", 
                                                  min: 0, max: 100 })
         .on("change", () => div_aligned.style.width = `${100 - view.aligned.pos}%`);
+
+    folder_aligned.addInput(view.aligned, "adjust_pos", { label: "adjust position" })
+        .on("change", () => update_aligned_panel_display());
+
+    folder_aligned.addInput(view.aligned, "padding", { label: "padding from tree", 
+                                                 min: 0, max: 600 })
+        .on("change", () => update_aligned_panel_display());
 }

--- a/ete4/smartview/gui/static/js/menu.js
+++ b/ete4/smartview/gui/static/js/menu.js
@@ -14,14 +14,87 @@ export { init_menus, update_folder_layouts };
 function init_menus(trees) {
     menus.pane = new Tweakpane.Pane()
         .addFolder({ title: "Control panel" });
+
     const tab = menus.pane.addTab({ pages: [
-        { title: "Tree view" },
-        { title: "Representation" },
-        { title: "Selection" },
+        { title: "Basic" },
+        { title: "Selections" },
+        { title: "Advanced" },
     ]});
-    create_menu_main(tab.pages[0], trees);
-    create_menu_representation(tab.pages[1]);
-    create_menu_selection(tab.pages[2]);
+    create_menu_basic(tab.pages[0], trees);
+    create_menu_selection(tab.pages[1]);
+
+
+    //const tab = menus.pane.addTab({ pages: [
+        //{ title: "Tree view" },
+        //{ title: "Representation" },
+        //{ title: "Selection" },
+    //]});
+    //create_menu_main(tab.pages[0], trees);
+    //create_menu_representation(tab.pages[1]);
+    //create_menu_selection(tab.pages[2]);
+}
+
+
+function create_menu_basic(menu, trees) {
+    
+    // trees
+    if (trees.length > 1) {
+        const options = trees.reduce((opt, t) => ({ ...opt, [t]: t }), {});
+        menu.addInput(view, "tree", {options: options}).on("change", () => {
+            view.subtree = "";
+            on_tree_change();
+        });
+    } else
+        menu.addMonitor(view, "tree",
+            { label: "tree" })
+
+    // upload 
+    if (view.upload)
+        menu.addButton({ title: "upload" }).on("click", view.upload);
+
+    // download
+    const folder_download = menu.addFolder({ title: "Download",
+                                                    expanded: false });
+    folder_download.addButton({ title: "newick" }).on("click", view.download.newick);
+    folder_download.addButton({ title: "svg" }).on("click", view.download.svg);
+
+
+    // drawer
+    const options = { "Rectangular": "RectFaces", "Circular": "CircFaces" };
+    menu.addInput(view.drawer, "name", { label: "drawer", options: options })
+        .on("change", on_drawer_change);
+
+    // min collapse size
+    menu.addInput(view, "min_size", { label: "collapse", 
+        min: 1, max: 100, step: 1 }).on("change", update);
+
+    // ultrametric
+    menu.addInput(view, "ultrametric", { label: "ultrametric" }).on("change", 
+        async () => {
+            await api(`/trees/${get_tid()}/ultrametric`);
+            update();
+    })
+
+    // topology only
+
+
+    // layouts
+    add_folder_layouts(menu, false);
+
+    // minimap
+    menus.minimap = menu.addInput(view.minimap, "show", { label: "show minimap" })
+        .on("change", () => show_minimap(view.minimap.show));
+
+    // tree scale legend
+    menu.addInput(view.tree_scale, "show", { label: "show tree scale legend" })
+        .on("change", draw_tree_scale);
+
+    // zooms
+    menu.addInput(view, "smart_zoom", { label: "smart zoom" });
+
+    menu.addInput(view.aligned, "zoom", { label: "zoom in aligned panel" });
+
+    menu.addButton({ title: "Help" }).on("click", view.show_help);
 }
 
 
@@ -80,17 +153,18 @@ function create_menu_representation(menu) {
 
     //add_folder_style(menu);
 
-    add_folder_layouts(menu);
+    //add_folder_layouts(menu);
 }
 
 
 function create_menu_selection(menu) {
     // filled dynamically in collapsed.js and select.js
-    menus.collapsed = menu.addFolder({ title: "Collapsed" }); 
-    menus.selected = menu.addFolder({ title: "Selected" });
+    menus.collapsed = menu.addFolder({ title: "Collapsed", expanded: false }); 
 
     view.active.folder = menu.addFolder({ title: `Active ${view.active.nodes.length}` });
     add_folder_active();
+
+    menus.selected = menu.addFolder({ title: "Selected", expanded: false });
 
     add_folder_searches(menu);
 }
@@ -146,14 +220,14 @@ function update_folder_layouts (){
 }
 
 
-function add_folder_layouts(menu) {
-    menus.layouts = menu.addFolder({ title: "Layouts" });
+function add_folder_layouts(menu, expanded=true) {
+    menus.layouts = menu.addFolder({ title: "Layouts", expanded: expanded });
     update_folder_layouts();
 }
 
 
 function add_folder_searches(menu) {
-    menus.searches = menu.addFolder({ title: "Searches" });
+    menus.searches = menu.addFolder({ title: "Searched" });
 
     menus.searches.addButton({ title: "new search" }).on("click", view.search);
 }
@@ -193,23 +267,6 @@ function add_folder_view(menu) {
         label: "Adjust zoom a", 
         format: v => v.toFixed(1),
         min: 1, max: div_tree.offsetWidth / view.tree_size.width }).on("change", update);
-
-    //const folder_zoom = folder_view.addFolder({ title: "Zoom" });
-
-    //folder_zoom.addInput(view.zoom, "x", { label: "x", 
-                                           //format: v => v.toFixed(1),
-                                           //min: 1, max: div_tree.offsetWidth })
-        //.on("change", update);
-    //folder_zoom.addInput(view.zoom, "y", { label: "y", 
-                                           //format: v => v.toFixed(3),
-                                           //min: 10**(-10), max: div_tree.offsetHeight, step: 10**(-10) })
-        //.on("change", update);
-
-    const folder_aligned = folder_view.addFolder({ title: "Aligned panel",
-                                                   expanded: false });
-    folder_aligned.addInput(view.aligned, "pos", { label: "position", 
-                                                 min: 0, max: 100 })
-        .on("change", () => div_aligned.style.width = `${100 - view.aligned.pos}%`);
 }
 
 
@@ -379,9 +436,8 @@ function add_folder_tree_scale(menu) {
     folder_scale.addInput(view.tree_scale, "color", { view: "color" })
         .on("change", draw_tree_scale);
 
-    folder_scale.addInput(view.tree_scale, "show", { view: "color" })
-        .on("change", draw_tree_scale);
-    
+    folder_scale.addInput(view.tree_scale, "show")
+        .on("change", draw_tree_scale); 
 }
 
 
@@ -403,4 +459,8 @@ function add_folder_aligned(menu) {
     folder_aligned.addInput(view.aligned.footer, "show", 
         { label: "show footer" })
         .on("change",() => draw_aligned());
+
+    folder_aligned.addInput(view.aligned, "pos", { label: "position", 
+                                                 min: 0, max: 100 })
+        .on("change", () => div_aligned.style.width = `${100 - view.aligned.pos}%`);
 }

--- a/ete4/smartview/gui/static/js/menu.js
+++ b/ete4/smartview/gui/static/js/menu.js
@@ -22,6 +22,7 @@ function init_menus(trees) {
     ]});
     create_menu_basic(tab.pages[0], trees);
     create_menu_selection(tab.pages[1]);
+    create_menu_advanced(tab.pages[2])
 
 
     //const tab = menus.pane.addTab({ pages: [
@@ -94,23 +95,7 @@ function create_menu_basic(menu, trees) {
 
     menu.addInput(view.aligned, "zoom", { label: "zoom in aligned panel" });
 
-    menu.addButton({ title: "Help" }).on("click", view.show_help);
-}
-
-
-function create_menu_main(menu, trees) {
-    add_folder_tree(menu, trees);
-
-    add_folder_info(menu);
-
-    add_folder_view(menu);
-
-    add_folder_minimap(menu);
-
-    add_folder_tree_scale(menu);
-
-    add_folder_aligned(menu);
-
+    // text select
     menu.addInput(view, "select_text", { label: "select text", position: 'left' })
       .on("change", () => {
         style("font").userSelect = (view.select_text ? "text" : "none");
@@ -118,26 +103,30 @@ function create_menu_main(menu, trees) {
         div_aligned.style.cursor = (view.select_text ? "text" : "ew-resize");
         set_boxes_clickable(!view.select_text);
     });
-    menu.addInput(view, "smart_zoom", { label: "smart zoom" });
+
     menu.addButton({ title: "share view" }).on("click", view.share_view);
     menu.addButton({ title: "Help" }).on("click", view.show_help);
 }
 
 
-function create_menu_representation(menu) {
-    const options = { "Rectangular": "RectFaces", "Circular": "CircFaces" };
-    menu.addInput(view.drawer, "name", { label: "drawer", options: options })
-        .on("change", on_drawer_change);
+function create_menu_advanced(menu) {
+    add_folder_info(menu);
 
-    menu.addInput(view, "min_size", { label: "collapse", 
-        min: 1, max: 100, step: 1 }).on("change", update);
+    add_folder_view(menu);
 
-    menu.addInput(view, "ultrametric", { label: "ultrametric" }).on("change", 
-        async () => {
-            await api(`/trees/${get_tid()}/ultrametric`);
-            update();
-    })
+    add_folder_circular(menu)
 
+    add_folder_sort(menu);
+
+    add_folder_minimap(menu);
+
+    add_folder_tree_scale(menu);
+
+    add_folder_aligned(menu);
+}
+
+
+function add_folder_circular(menu) {
     const folder_circ = menu.addFolder({ title: "Circular", expanded: false });
 
     function update_with_minimap() {
@@ -170,35 +159,12 @@ function create_menu_selection(menu) {
 }
 
 
-function add_folder_tree(menu, trees) {
-    const folder_tree = menu.addFolder({ title: "Tree" });
-
-    if (trees.length > 1) {
-        const options = trees.reduce((opt, t) => ({ ...opt, [t]: t }), {});
-        folder_tree.addInput(view, "tree", {options: options}).on("change", () => {
-            view.subtree = "";
-            on_tree_change();
-        });
-    } else
-        folder_tree.addMonitor(view, "tree",
-            { label: "tree" })
-
-    menus.subtree = folder_tree.addInput(view, "subtree", 
-        { value: view.subtree }).on("change", on_tree_change);
-
-    const folder_sort = folder_tree.addFolder({ title: "Sort",
+function add_folder_sort(menu) {
+    const folder_sort = menu.addFolder({ title: "Sort",
                                                 expanded: false });
     folder_sort.addButton({ title: "sort" }).on("click", view.sorting.sort);
     folder_sort.addInput(view.sorting, "key");
     folder_sort.addInput(view.sorting, "reverse");
-
-    if (view.upload)
-        folder_tree.addButton({ title: "upload" }).on("click", view.upload);
-
-    const folder_download = folder_tree.addFolder({ title: "Download",
-                                                    expanded: false });
-    folder_download.addButton({ title: "newick" }).on("click", view.download.newick);
-    folder_download.addButton({ title: "svg" }).on("click", view.download.svg);
 }
 
 
@@ -235,6 +201,9 @@ function add_folder_searches(menu) {
 
 function add_folder_info(menu) {
     const folder_info = menu.addFolder({ title: "Info", expanded: false });
+    
+    menus.subtree = folder_info.addInput(view, "subtree", 
+        { value: view.subtree }).on("change", on_tree_change);
     
     const folder_nodes = folder_info.addFolder({ title: "Nodes", expanded: true });
     folder_nodes.addMonitor(view, "nnodes", 
@@ -444,10 +413,6 @@ function add_folder_tree_scale(menu) {
 function add_folder_aligned(menu) {
     const folder_aligned = menu.addFolder(
         { title: "Aligned panel", expanded: false });
-
-    folder_aligned.addInput(view.aligned, "zoom", 
-        { label: "zoom" });
-
 
     folder_aligned.addInput(view.aligned, "adjust_zoom", 
         { label: "adjust zoom" });

--- a/ete4/smartview/renderer/drawer.py
+++ b/ete4/smartview/renderer/drawer.py
@@ -450,7 +450,6 @@ class Drawer:
         # Uses self.collapsed and self.outline to extract and place info.
 
 
-
 class DrawerRect(Drawer):
     "Minimal functional drawer for a rectangular representation"
 

--- a/ete4/smartview/renderer/drawer.py
+++ b/ete4/smartview/renderer/drawer.py
@@ -138,9 +138,10 @@ class Drawer:
         is_manually_collapsed = it.node_id in self.collapsed_ids
 
         if is_manually_collapsed and self.outline:
-            graphics += self.get_outline()  # so we won't stack with its outline
+            graphics += self.get_outline(it.node_id)  # so we won't stack with its outline
 
         if is_manually_collapsed or self.is_small(box_node):
+            print("HEELOO", is_manually_collapsed)
             self.node_dxs[-1].append(box_node.dx)
             self.collapsed.append(it.node)
             self.outline = stack(self.outline, box_node)
@@ -178,6 +179,8 @@ class Drawer:
                         if any(node in results or node in parents.keys() for node in self.collapsed) )
                 active_children = self.get_active_children()
                 selected_children = self.get_selected_children()
+
+            print("lastt", it.node_id in self.collapsed_ids)
             graphics += self.get_outline()
 
         x_after, y_after = point
@@ -318,7 +321,7 @@ class Drawer:
 
         return graphics
 
-    def get_outline(self):
+    def get_outline(self, node_id=None):
         "Yield the outline representation"
         graphics = []
 
@@ -357,7 +360,7 @@ class Drawer:
             name, properties = collapsed_node.name, collapsed_node.props
 
             box = draw_nodebox(self.flush_outline(ndx), name, 
-                    properties, [], searched_by + selected_by + active_by,
+                    properties, node_id or [], searched_by + selected_by + active_by,
                     { 'fill': collapsed_node.sm_style.get('bgcolor') })
             self.nodeboxes.append(box)
         else:

--- a/ete4/smartview/renderer/layouts/__init__.py
+++ b/ete4/smartview/renderer/layouts/__init__.py
@@ -1,1 +1,2 @@
 from . import phylocloud_egg5_layouts
+from . import context_layouts

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -1,0 +1,62 @@
+from ..treelayout import TreeLayout
+from ..faces import ArrowFace
+
+
+__all__ = [ "LayoutGenomicContext" ]
+
+
+class LayoutGenomicContext(TreeLayout):
+
+    def __init__(self, nside=2, name="Genomic context",
+            width=70, height=15, collapse_size=1,
+            stroke_color="gray", stroke_width="1.5px",
+            anchor_stroke_color="black", anchor_stroke_width="3px"):
+
+        super().__init__(name, aligned_faces=True)
+
+        self.nside = nside
+
+        self.width = width
+        self.height = height
+
+        self.collapse_size = collapse_size
+
+        self.anchor_stroke_color = anchor_stroke_color
+        self.anchor_stroke_width = anchor_stroke_width
+        self.stroke_color = stroke_color
+        self.stroke_width = stroke_width
+
+    def set_tree_style(self, style):
+        super().set_tree_style(style)
+        style.collapse_size = self.collapse_size
+
+    def set_node_style(self, node):
+        if node.is_leaf():
+            context = node.props.get("_context")
+        else:
+            first_leaf = next(node.iter_leaves())
+            context = first_leaf.props.get("_context")
+        if context:
+            for idx, gene in enumerate(context):
+                name = gene.get("name")
+                color = gene.get("color", "gray")
+                strand = gene.get("strand", "+")
+                cluster = gene.get("cluster")
+                orientation = "left" if strand == "-" else "right"
+                text = name + " #" + cluster
+                if idx == self.nside:
+                    stroke_color = self.anchor_stroke_color
+                    stroke_width = self.anchor_stroke_width
+                else:
+                    stroke_color = self.stroke_color
+                    stroke_width = self.stroke_width
+                props = {"name": name, "cluster": cluster}
+                tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
+                arrow = ArrowFace(self.width, self.height,
+                        orientation=orientation, color=color,
+                        stroke_color=stroke_color, stroke_width=stroke_width,
+                        tooltip=tooltip,
+                        text=text,
+                        padding_x=2, padding_y=2)
+                node.add_face(arrow, position="aligned", column=idx,
+                        collapsed_only=(not node.is_leaf()))

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -101,6 +101,7 @@ class LayoutGenomicContext(TreeLayout):
             first_leaf = next(node.iter_leaves())
             return first_leaf.props.get("_context")
 
+        # Compute conserved context by color
         color_context = defaultdict(list)
         color2genes = {}
 
@@ -123,6 +124,5 @@ class LayoutGenomicContext(TreeLayout):
                     "vertical_conservation": n / ntips })
             else:
                 context.append({ "color": self.non_conserved_color })
-
 
         return context

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -115,7 +115,6 @@ class LayoutGenomicContext(TreeLayout):
         ntips = len(node)
         context = []
         for pos, colors in sorted(color_context.items()):
-            print(pos)
             color, n = Counter(colors).most_common(1)[0]
             if n / ntips >= self.collapse_conservation\
                 and color != self.non_conserved_color:

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -94,4 +94,4 @@ class LayoutGenomicContext(TreeLayout):
 
         first_leaf = next(node.iter_leaves())
         context = first_leaf.props.get("_context")
-
+        return context

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -45,7 +45,8 @@ class LayoutGenomicContext(TreeLayout):
                 name = gene.get("name")
                 color = gene.get("color", "gray")
                 conservation = gene.get("conservation_score")
-                if conservation and conservation >= self.conservation_threshold:
+                if conservation is not None\
+                    and float(conservation) >= self.conservation_threshold:
                     color = self.non_conserved_color
                 strand = gene.get("strand", "+")
                 cluster = gene.get("cluster")

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -48,7 +48,7 @@ class LayoutGenomicContext(TreeLayout):
                 color = gene.get("color", self.non_conserved_color)
                 conservation = gene.get("conservation_score")
                 if conservation is not None\
-                    and float(conservation) >= self.conservation_threshold:
+                    and float(conservation) < self.conservation_threshold:
                     color = self.non_conserved_color
                 strand = gene.get("strand", "+")
                 cluster = gene.get("cluster")

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -62,7 +62,7 @@ class LayoutGenomicContext(TreeLayout):
                     stroke_color = self.stroke_color
                     stroke_width = self.stroke_width
 
-                if self.tooltip_props:
+                if self.tooltip_props is not None:
                     if self.tooltip_props == []:
                         key_props = gene.keys()
                     else:

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -9,7 +9,7 @@ class LayoutGenomicContext(TreeLayout):
 
     def __init__(self, name="Genomic context", nside=2,
             conservation_threshold=0, width=70, height=15, collapse_size=1,
-            gene_name="name",
+            gene_name="name", tooltip_props=[],
             stroke_color="gray", stroke_width="1.5px",
             anchor_stroke_color="black", anchor_stroke_width="3px",
             non_conserved_color="#d0d0d0"):
@@ -19,6 +19,7 @@ class LayoutGenomicContext(TreeLayout):
         self.nside = nside
         self.conservation_threshold = conservation_threshold
         self.gene_name
+        self.tooltip_props = tooltip_props
 
         self.width = width
         self.height = height
@@ -60,8 +61,17 @@ class LayoutGenomicContext(TreeLayout):
                 else:
                     stroke_color = self.stroke_color
                     stroke_width = self.stroke_width
-                props = { k:v for k,v in gene.items() if k not in ("strand", "color") }
-                tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
+
+                if self.tooltip_props:
+                    if self.tooltip_props == []:
+                        key_props = gene.keys()
+                    else:
+                        key_props = self.tooltip_props
+
+                    props = { k:v for k,v in gene.items() if k in key_props and k not in ("strand", "color") }
+                    tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
+                else:
+                    tooltip = ""
                 arrow = ArrowFace(self.width, self.height,
                         orientation=orientation, color=color,
                         stroke_color=stroke_color, stroke_width=stroke_width,

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -57,28 +57,35 @@ class LayoutGenomicContext(TreeLayout):
                 else:
                     stroke_color = self.stroke_color
                     stroke_width = self.stroke_width
-
-                if self.tooltip_props is not None:
-                    if self.tooltip_props == []:
-                        key_props = gene.keys()
-                    else:
-                        key_props = self.tooltip_props
-
-                    props = { k:v for k,v in gene.items()\
-                            if k in key_props\
-                            and v\
-                            and k not in ("strand", "color") }
-                    tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
-                else:
-                    tooltip = ""
                 arrow = ArrowFace(self.width, self.height,
                         orientation=orientation, color=color,
                         stroke_color=stroke_color, stroke_width=stroke_width,
-                        tooltip=tooltip,
+                        tooltip=self.get_tooltip(gene),
                         text=text,
                         padding_x=2, padding_y=2)
                 node.add_face(arrow, position="aligned", column=idx,
                         collapsed_only=(not node.is_leaf()))
+
+
+    def get_tooltip(self, gene):
+        if self.tooltip_props is None:
+            return ""
+
+        if self.tooltip_props == []:
+            key_props = gene.keys()
+        else:
+            key_props = self.tooltip_props
+
+        props = {}
+        for k,v in gene.items():
+            if k in key_props and v and not k in ("strand", "color"):
+                if k == "hyperlink":
+                    k = "Go to"
+                    label, url = v
+                    v = f'<a href="{url}" target="_blank">{label}</a>'
+                props[k] = v
+
+        return "<br>".join(f'{k}: {v}' for k,v in props.items())
 
 
     def get_context(self, node):

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -18,7 +18,7 @@ class LayoutGenomicContext(TreeLayout):
 
         self.nside = nside
         self.conservation_threshold = conservation_threshold
-        self.gene_name
+        self.gene_name = gene_name
         self.tooltip_props = tooltip_props
 
         self.width = width

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -7,14 +7,16 @@ __all__ = [ "LayoutGenomicContext" ]
 
 class LayoutGenomicContext(TreeLayout):
 
-    def __init__(self, nside=2, name="Genomic context",
-            width=70, height=15, collapse_size=1,
+    def __init__(self, name="Genomic context", nside=2,
+            conservation_threshold=0, width=70, height=15, collapse_size=1,
             stroke_color="gray", stroke_width="1.5px",
-            anchor_stroke_color="black", anchor_stroke_width="3px"):
+            anchor_stroke_color="black", anchor_stroke_width="3px",
+            non_conserved_color="#d0d0d0"):
 
         super().__init__(name, aligned_faces=True)
 
         self.nside = nside
+        self.conservation_threshold = conservation_threshold
 
         self.width = width
         self.height = height
@@ -25,6 +27,8 @@ class LayoutGenomicContext(TreeLayout):
         self.anchor_stroke_width = anchor_stroke_width
         self.stroke_color = stroke_color
         self.stroke_width = stroke_width
+
+        self.non_conserved_color = non_conserved_color
 
     def set_tree_style(self, style):
         super().set_tree_style(style)
@@ -40,6 +44,9 @@ class LayoutGenomicContext(TreeLayout):
             for idx, gene in enumerate(context):
                 name = gene.get("name")
                 color = gene.get("color", "gray")
+                conservation = gene.get("conservation_score")
+                if conservation and conservation >= self.conservation_threshold:
+                    color = self.non_conserved_color
                 strand = gene.get("strand", "+")
                 cluster = gene.get("cluster")
                 orientation = "left" if strand == "-" else "right"

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -38,11 +38,7 @@ class LayoutGenomicContext(TreeLayout):
         style.collapse_size = self.collapse_size
 
     def set_node_style(self, node):
-        if node.is_leaf():
-            context = node.props.get("_context")
-        else:
-            first_leaf = next(node.iter_leaves())
-            context = first_leaf.props.get("_context")
+        context = self.get_context(node)
         if context:
             for idx, gene in enumerate(context):
                 name = gene.get("name")
@@ -68,7 +64,10 @@ class LayoutGenomicContext(TreeLayout):
                     else:
                         key_props = self.tooltip_props
 
-                    props = { k:v for k,v in gene.items() if k in key_props and k not in ("strand", "color") }
+                    props = { k:v for k,v in gene.items()\
+                            if k in key_props\
+                            and v\
+                            and k not in ("strand", "color") }
                     tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
                 else:
                     tooltip = ""
@@ -80,3 +79,12 @@ class LayoutGenomicContext(TreeLayout):
                         padding_x=2, padding_y=2)
                 node.add_face(arrow, position="aligned", column=idx,
                         collapsed_only=(not node.is_leaf()))
+
+
+    def get_context(self, node):
+        if node.is_leaf():
+            return node.props.get("_context")
+
+        first_leaf = next(node.iter_leaves())
+        context = first_leaf.props.get("_context")
+

--- a/ete4/smartview/renderer/layouts/context_layouts.py
+++ b/ete4/smartview/renderer/layouts/context_layouts.py
@@ -9,6 +9,7 @@ class LayoutGenomicContext(TreeLayout):
 
     def __init__(self, name="Genomic context", nside=2,
             conservation_threshold=0, width=70, height=15, collapse_size=1,
+            gene_name="name",
             stroke_color="gray", stroke_width="1.5px",
             anchor_stroke_color="black", anchor_stroke_width="3px",
             non_conserved_color="#d0d0d0"):
@@ -17,6 +18,7 @@ class LayoutGenomicContext(TreeLayout):
 
         self.nside = nside
         self.conservation_threshold = conservation_threshold
+        self.gene_name
 
         self.width = width
         self.height = height
@@ -43,7 +45,7 @@ class LayoutGenomicContext(TreeLayout):
         if context:
             for idx, gene in enumerate(context):
                 name = gene.get("name")
-                color = gene.get("color", "gray")
+                color = gene.get("color", self.non_conserved_color)
                 conservation = gene.get("conservation_score")
                 if conservation is not None\
                     and float(conservation) >= self.conservation_threshold:
@@ -51,14 +53,14 @@ class LayoutGenomicContext(TreeLayout):
                 strand = gene.get("strand", "+")
                 cluster = gene.get("cluster")
                 orientation = "left" if strand == "-" else "right"
-                text = name + " #" + cluster
+                text = gene.get(self.gene_name, "")
                 if idx == self.nside:
                     stroke_color = self.anchor_stroke_color
                     stroke_width = self.anchor_stroke_width
                 else:
                     stroke_color = self.stroke_color
                     stroke_width = self.stroke_width
-                props = {"name": name, "cluster": cluster}
+                props = { k:v for k,v in gene.items() if k not in ("strand", "color") }
                 tooltip = "\n".join(f'{k}: {v}' for k,v in props.items())
                 arrow = ArrowFace(self.width, self.height,
                         orientation=orientation, color=color,

--- a/ete4/smartview/renderer/treestyle.py
+++ b/ete4/smartview/renderer/treestyle.py
@@ -16,7 +16,7 @@ class TreeStyle(object):
 
         self.ultrametric = False
 
-        self.collapse_size = 6
+        self.collapse_size = 10
 
         # Selected face
         self._selected_face = SelectedRectFace


### PR DESCRIPTION
- Reorganized control panel: basic and advance. Collapsed nodes removed from selection tab (you can uncollapse a node by right clicking > uncollapse)
- Tooltips for SVG faces. Accept HTML. TODO: tooltips in pixi faces
- LayoutGenomicContext included in context_layouts. Computes collapsed-node context by conservation