### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,10 @@ try:
         provides = [MOD_NAME],
         keywords = "tree, tree reconstruction, tree visualization, tree comparison, phylogeny, phylogenetics, phylogenomics",
         url = "http://etetoolkit.org",
+        project_urls = {
+            "Documentation": "http://etetoolkit.org/docs/latest/tutorial/index.html",
+            "Source": "https://github.com/etetoolkit/ete",
+        },
         download_url = "http://etetoolkit.org/static/releases/ete3/",
 
     )


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)