### PR TITLE
fix typing error

### DIFF
--- a/ete3/treeview/main.py
+++ b/ete3/treeview/main.py
@@ -749,10 +749,10 @@ def save(scene, imgName, w=None, h=None, dpi=90,\
         scene.render(pp, targetRect, scene.sceneRect(), ratio_mode)
     else:
         targetRect = QRectF(0, 0, w, h)
-        ii= QImage(w, h, QImage.Format_ARGB32)
+        ii= QImage(int(w), int(h), int(QImage.Format_ARGB32))
         ii.fill(QColor(Qt.white).rgb())
-        ii.setDotsPerMeterX(dpi / 0.0254) # Convert inches to meters
-        ii.setDotsPerMeterY(dpi / 0.0254)
+        ii.setDotsPerMeterX(int(dpi / 0.0254)) # Convert inches to meters
+        ii.setDotsPerMeterY(int(dpi / 0.0254))
         pp = QPainter(ii)
         pp.setRenderHint(QPainter.Antialiasing)
         pp.setRenderHint(QPainter.TextAntialiasing)

--- a/ete3/treeview/qt4_gui.py
+++ b/ete3/treeview/qt4_gui.py
@@ -72,7 +72,7 @@ class _SelectorItem(QGraphicsRectItem):
     def paint(self, p, option, widget):
         p.setPen(self.Color)
         p.setBrush(QBrush(Qt.NoBrush))
-        p.drawRect(self.rect().x(),self.rect().y(),self.rect().width(),self.rect().height())
+        p.drawRect(int(self.rect().x()), int(self.rect().y()), int(self.rect().width()), int(self.rect().height()))
         return
         # Draw info text
         font = QFont("Arial",13)
@@ -169,7 +169,7 @@ class _GUI(QMainWindow):
         # Shows the whole tree by default
         #self.view.fitInView(self.scene.sceneRect(), Qt.KeepAspectRatio)
         splitter.setCollapsible(1, True)
-        splitter.setSizes([self.scene.sceneRect().width(), 10])
+        splitter.setSizes([int(self.scene.sceneRect().width()), 10])
 
         self.view.fitInView(0, 0, self.scene.sceneRect().width(), 200, Qt.KeepAspectRatio)
 


### PR DESCRIPTION
ref issue: #616; 

this could be an issue with how ete interfaces with PyQt; but as a provisional fix, casting all inputs to draw as int will let the tree render instead of raising `index 0 has type 'float' but 'int' is expected`