### PR TITLE
Fix floating numbers in (drawer.render_tree function)

### DIFF
--- a/ete3/treeview/main.py
+++ b/ete3/treeview/main.py
@@ -749,10 +749,10 @@ def save(scene, imgName, w=None, h=None, dpi=90,\
         scene.render(pp, targetRect, scene.sceneRect(), ratio_mode)
     else:
         targetRect = QRectF(0, 0, w, h)
-        ii= QImage(w, h, QImage.Format_ARGB32)
+        ii= QImage(round(w), round(h), QImage.Format_ARGB32)
         ii.fill(QColor(Qt.white).rgb())
-        ii.setDotsPerMeterX(dpi / 0.0254) # Convert inches to meters
-        ii.setDotsPerMeterY(dpi / 0.0254)
+        ii.setDotsPerMeterX(round(dpi / 0.0254)) # Convert inches to meters
+        ii.setDotsPerMeterY(round(dpi / 0.0254))
         pp = QPainter(ii)
         pp.setRenderHint(QPainter.Antialiasing)
         pp.setRenderHint(QPainter.TextAntialiasing)


### PR DESCRIPTION
Solve Error:
 
t.render("phylotree.png", w=750)
  File "...\Programs\Python\Python310\lib\site-packages\ete3\coretype\tree.py", line 1392, in render
    return drawer.render_tree(self, file_name, w=w, h=h,
  File "...\Programs\Python\Python310\lib\site-packages\ete3\treeview\drawer.py", line 113, in render_tree
    x_scale, y_scale = save(scene, imgName, w=w, h=h, units=units, dpi=dpi)
  File "...\Programs\Python\Python310\lib\site-packages\ete3\treeview\main.py", line 754, in save
    ii.setDotsPerMeterX(dpi / 0.0254) # Convert inches to meters
TypeError: setDotsPerMeterX(self, int): argument 1 has unexpected type 'float'1 has unexpected type 'float'