### PR TITLE
set determination for popup_prop_keys

### DIFF
--- a/ete4/smartview/gui/server.py
+++ b/ete4/smartview/gui/server.py
@@ -1178,7 +1178,8 @@ def add_tree(data):
     app_tree.name = name
     app_tree.tree = tree
     app_tree.layouts = retrieve_layouts(layouts)
-    app_tree.popup_prop_keys = popup_prop_keys
+    if popup_prop_keys: # if data doesn't come from post, this popup_prop_keys will be empty
+        app_tree.popup_prop_keys = popup_prop_keys
 
     print("Tree added to app.trees")
 


### PR DESCRIPTION
The change I made is to prevent popup_prop_keys goes to [] if the tree comes from local instead of post. 

Using example in https://github.com/dengzq1234/ete4_gallery/blob/master/ete4_textface.py, without determination, the popup_prop_keys will be [] because data comes from local instead of post, hence the tree won't have popup_prop_keys

