### PR TITLE
Resolve #649. Fix bug in populate() method

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1215,8 +1215,8 @@ class TreeNode(object):
             if random_branches:
                 c1.dist = random.uniform(*branch_range)
                 c2.dist = random.uniform(*branch_range)
-                c1.support = random.uniform(*branch_range)
-                c2.support = random.uniform(*branch_range)
+                c1.support = random.uniform(*support_range)
+                c2.support = random.uniform(*support_range)
             else:
                 c1.dist = 1.0
                 c2.dist = 1.0


### PR DESCRIPTION
In the `populate()` method, `branch_range` was used instead of `support_range`, as noticed in Issue #649 