### PR TITLE
Do not try to add `treeview.Face` when it is not available

### DIFF
--- a/ete4/coretype/tree.pyx
+++ b/ete4/coretype/tree.pyx
@@ -2227,7 +2227,7 @@ cdef class Tree(object):
 
     def add_face(self, face, column=0, position='branch-right',
                  collapsed_only=False):
-        if isinstance(face, Face):
+        if TREEVIEW and isinstance(face, Face):
             self.add_face_treeview(face, column, position)
         elif isinstance(face, smartFace):
             self.add_face_smartview(face, column, position, collapsed_only)


### PR DESCRIPTION
Hi,

This PR fixes an `ImportError` that occurrs when PyQt5 is not installed and `add_face` is called in the smartview renderer.