### PR TITLE
Remove PyQt5 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Visualization",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["bottle", "brotli", "numpy", "pyqt5"]
+dependencies = ["bottle", "brotli", "numpy"]
 
 [project.urls]
 "Homepage" = "https://etetoolkit.org"


### PR DESCRIPTION
Hi,

this removes the PyQt5 dependency, and will probably expose many issues when PyQt5 is actually not installed.