### PR TITLE
Fix broken str.join() in ncbiquery.generate_table()

### DIFF
--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -652,13 +652,13 @@ def generate_table(t):
             track.append(temp_node.name)
             temp_node = temp_node.up
         if n.up:
-            print('\t'.join(n.name, n.up.name, n.props.get('taxname'),
-                            n.props.get("common_name", ''), n.props.get("rank"),
-                            ','.join(track)), file=OUT)
+            print('\t'.join([n.name, n.up.name, n.props.get('taxname'),
+                             n.props.get("common_name", ''), n.props.get("rank"),
+                             ','.join(track)]), file=OUT)
         else:
-            print('\t'.join(n.name, "", n.props.get('taxname'),
-                            n.props.get("common_name", ''), n.props.get("rank"),
-                            ','.join(track)), file=OUT)
+            print('\t'.join([n.name, "", n.props.get('taxname'),
+                             n.props.get("common_name", ''), n.props.get("rank"),
+                             ','.join(track)]), file=OUT)
     OUT.close()
 
 def update_db(dbfile, targz_file=None):

--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -651,14 +651,12 @@ def generate_table(t):
         while temp_node:
             track.append(temp_node.name)
             temp_node = temp_node.up
-        if n.up:
-            print('\t'.join([n.name, n.up.name, n.props.get('taxname'),
-                             n.props.get("common_name", ''), n.props.get("rank"),
-                             ','.join(track)]), file=OUT)
-        else:
-            print('\t'.join([n.name, "", n.props.get('taxname'),
-                             n.props.get("common_name", ''), n.props.get("rank"),
-                             ','.join(track)]), file=OUT)
+
+        n_up_name = n.up.name if n.up else ""
+
+        print('\t'.join([n.name, n_up_name, n.props.get('taxname'),
+                         n.props.get("common_name", ''), n.props.get("rank"),
+                         ','.join(track)]), file=OUT)
     OUT.close()
 
 def update_db(dbfile, targz_file=None):

--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -642,22 +642,21 @@ def load_ncbi_tree_from_dump(tar):
     return t, synonyms
 
 def generate_table(t):
-    OUT = open("taxa.tab", "w")
-    for j, n in enumerate(t.traverse()):
-        if j % 1000 == 0:
-            print("\r",j,"generating entries...", end=' ')
-        temp_node = n
-        track = []
-        while temp_node:
-            track.append(temp_node.name)
-            temp_node = temp_node.up
+    with open("taxa.tab", "w") as out:
+        for j, n in enumerate(t.traverse()):
+            if j % 1000 == 0:
+                print("\r",j,"generating entries...", end=' ')
+            temp_node = n
+            track = []
+            while temp_node:
+                track.append(temp_node.name)
+                temp_node = temp_node.up
 
-        n_up_name = n.up.name if n.up else ""
+            n_up_name = n.up.name if n.up else ""
 
-        print('\t'.join([n.name, n_up_name, n.props.get('taxname'),
-                         n.props.get("common_name", ''), n.props.get("rank"),
-                         ','.join(track)]), file=OUT)
-    OUT.close()
+            print('\t'.join([n.name, n_up_name, n.props.get('taxname'),
+                             n.props.get("common_name", ''), n.props.get("rank"),
+                             ','.join(track)]), file=out)
 
 def update_db(dbfile, targz_file=None):
     basepath = os.path.split(dbfile)[0]

--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -654,9 +654,11 @@ def generate_table(t):
 
             n_up_name = n.up.name if n.up else ""
 
-            print('\t'.join([n.name, n_up_name, n.props.get('taxname'),
+            row = '\t'.join([n.name, n_up_name, n.props.get('taxname'),
                              n.props.get("common_name", ''), n.props.get("rank"),
-                             ','.join(track)]), file=out)
+                             ','.join(track)])
+
+            print(row, file=out)
 
 def update_db(dbfile, targz_file=None):
     basepath = os.path.split(dbfile)[0]


### PR DESCRIPTION
A recent commit (7024539) introduced a bug which broke the ability to load the NCBI taxonomy by running `ete4.NCBITaxa()`.
This PR fixes that bug by making sure that `str.join` gets a list as its single parameter. I also refactored the function slightly while I was at it to use the more pythonic context manager rather than manually opening and closing the file handle and to reduce code duplication.

All 5 tests pass after running `python -m unittest tests.test_ncbiquery`