### PR TITLE
Refactor set outgroup function and update tests

### DIFF
--- a/ete4/coretype/tree.pyx
+++ b/ete4/coretype/tree.pyx
@@ -614,7 +614,7 @@ cdef class Tree(object):
                 if preserve_branch_length:
                     if len(n.children) == 1:
                         n.children[0].dist += n.dist
-                    elif len(n.children) > 1 and n.up:
+                    elif len(n.children) > 1 and n.up and n.up.dist:
                         n.up.dist += n.dist
 
                 n.delete(prevent_nondicotomic=False)
@@ -882,7 +882,7 @@ cdef class Tree(object):
         :param topological: If True, distance will refer to the number of
             nodes between target and target2.
         """
-        d = (lambda node: 1) if topological else (lambda node: node.dist)
+        d = (lambda node: 1) if topological else (lambda node: node.dist or 0.0)
 
         node1, node2 = self._translate_nodes([node1, node2])
 
@@ -1036,8 +1036,8 @@ cdef class Tree(object):
         else:
             root = self
 
-        root.dist = root.dist or 0
-        root.support = root.support or 1
+        #root.dist = root.dist or 0
+        #root.support = root.support or 1
 
         next_deq = deque([root])  # will contain the current leaves
         for i in range(size - 1):
@@ -1076,7 +1076,7 @@ cdef class Tree(object):
 
                 node.name = name
 
-    def set_outgroup_v2(self, outgroup, branch_properties=None):
+    def set_outgroup(self, outgroup, branch_properties=None):
         """Set the given outgroup node at the root and return it.
 
         :param outgroup: The node too use as future root.
@@ -1085,7 +1085,7 @@ cdef class Tree(object):
         from ..smartview.renderer.gardening import root_at
         return root_at(outgroup, branch_properties)
 
-    def set_outgroup(self, outgroup):
+    def set_outgroup_old(self, outgroup):
         """
         Sets a descendant node as the outgroup of a tree.  This function
         can be used to root a tree or even an internal node.

--- a/ete4/smartview/renderer/gardening.pyx
+++ b/ete4/smartview/renderer/gardening.pyx
@@ -24,7 +24,18 @@ def root_at(outgroup, bprops=None):
     assert outgroup != t, 'cannot set the absolute tree root as an outgroup'
 
     if len(t.children) > 2:
-        t.resolve_polytomy(recursive=False)
+        new_node = t.__class__()
+        for ch in list(t.children[1:]):
+            t.children.remove(ch)
+            new_node.children.append(ch)
+            ch.up = new_node
+
+        for bprop in ['support'] + (bprops or []):
+            if t.children[0].props.get(bprop, None) is not None:
+                new_node.props[bprop] = t.children[0].props[bprop]
+        t.children.append(new_node)
+        new_node.up = t
+
 
     # if node is already a direct child of the root node, we  just make sure the
     # outgroup is the "first" child and branch distances are balanced
@@ -55,10 +66,10 @@ def root_at(outgroup, bprops=None):
     # transfer branch properties from the original root node to the new
     # intermediate node We just want those props to be transferred, the rest
     # should stay in tree node.
-    if bprops:
-        for p in bprops:
-            if p in t.props:
-                intermediate_node.props[p] = copy.deepcopy(t.props[p])
+    #if bprops:
+    #    for p in bprops:
+    #        if p in t.props:
+    #            intermediate_node.props[p] = copy.deepcopy(t.props[p])
 
     # Now, let's place the original absolute tree root instance in the branch
     # that will become the new root, spliting the branch into two

--- a/ete4/smartview/renderer/gardening.pyx
+++ b/ete4/smartview/renderer/gardening.pyx
@@ -16,7 +16,68 @@ def sort(tree, key=None, reverse=False):
     tree.children.sort(key=key, reverse=reverse)
 
 
-def root_at(node, bprops=None):
+def root_at(outgroup, bprops=None):
+    """ set the node "outgroup" as the first child of its current tree root """
+    import copy
+
+    t = outgroup.root
+    assert outgroup != t, 'cannot set the absolute tree root as an outgroup'
+
+    if len(t.children) > 2:
+        t.resolve_polytomy(recursive=False)
+
+    # if node is already a direct child of the root node, we  just make sure the
+    # outgroup is the "first" child and branch distances are balanced
+    if outgroup.up == t:
+        t.children.remove(outgroup)
+        t.children.insert(0, outgroup)
+
+        # balance distances
+        total_dist = (t.children[0].dist or 0.0) + (t.children[1].dist or 0.0)
+        t.children[0].dist = total_dist / 2.0
+        t.children[1].dist = total_dist / 2.0
+
+        return t
+
+    # if the outgroup is somewhere down in the tree structure, we want to rehang
+    # all branches but keep keep the original absolute tree root instance
+    # intact.
+    #
+    # So let's first detach current tree root from the tree and create another node
+    # instance (intermediate) that replaces it in the topology
+    intermediate_node = t.__class__()
+    intermediate_node.name = "inter"
+    for ch in t.children:
+        intermediate_node.add_child(ch)
+    t.children = []
+    t.up = None
+
+    # transfer branch properties from the original root node to the new
+    # intermediate node We just want those props to be transferred, the rest
+    # should stay in tree node.
+    if bprops:
+        for p in bprops:
+            if p in t.props:
+                intermediate_node.props[p] = copy.deepcopy(t.props[p])
+
+    # Now, let's place the original absolute tree root instance in the branch
+    # that will become the new root, spliting the branch into two
+    split_branch(outgroup, bprops, t)
+
+    # and then rehang all nodes above the new outgroup, tranferring bprops
+    # appropriately
+    old_root, node_id = get_root_id(t)
+    root = old_root  # current root, which will change in each iteration
+    for child_pos in node_id:
+        root = rehang(root, child_pos, bprops)
+
+    # clean up topology to avoid a single-child node derived from the old root
+    if len(old_root.children) == 1:
+        join_branch(old_root)
+
+    return root
+
+def root_at_orig(node, bprops=None):
     """Return the tree of which node is part of, rerooted at the given node.
 
     :param node: Node where to set root (future first child of the new root).
@@ -32,7 +93,7 @@ def root_at(node, bprops=None):
         old_root.children.insert(0, node)   # the 1st child of the root node
         return old_root  # keep the same root node as before
 
-    split_branch(node, bprops)
+    inter = split_branch(node, bprops)
 
     root = old_root  # current root, which will change in each iteration
     for child_pos in node_id:
@@ -40,6 +101,8 @@ def root_at(node, bprops=None):
 
     if len(old_root.children) == 1:
         join_branch(old_root)
+
+    print(inter ==  root)
 
     return root
 
@@ -91,7 +154,7 @@ def swap_props(n1, n2, props):
             n1.props[pname] = p2
 
 
-def split_branch(node, bprops=None):
+def split_branch(node, bprops=None, intermediate=None):
     """Add an intermediate parent to the given node and return it."""
     # == up ======= node  ->  == up === intermediate === node
     up = node.up
@@ -99,7 +162,8 @@ def split_branch(node, bprops=None):
     pos_in_parent = up.children.index(node)  # save its position in parent
     up.children.pop(pos_in_parent)  # detach from parent
 
-    intermediate = node.__class__()  # create intermediate node (of same type)
+    if intermediate is None:
+        intermediate = node.__class__()  # create intermediate node (of same type)
     intermediate.add_child(node)
 
     if 'dist' in node.props:  # split dist between the new and old nodes


### PR DESCRIPTION
@jordibc, I have created a new root_at() function that uses smartview gardening methods but respects (hopefully) previous behaviour of set outgroup. 

The main difference between your root_at and set_outgroup was that the absolute tree root instance was never changed in set_outgroup, so there was no need to return the new root node. 

I also had to change tree.populate() so it does not initialize the tree root node with default and arbitrary support and dist values, which makes no sense now that we handle the absence of values explicitly. 

I updated all the tests accordingly, which are apparently passing now. 

btw, it looks weird that set_outgroup() is importing gardening from smarview.rendered. Wouldn't make more sense to have such module close tree.pyx and smarview importing from there? 

Please review and let me know!


