### PR TITLE
Add feature in `populate` method to sample from common tree distributions

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1234,6 +1234,8 @@ class TreeNode(object):
             root = self.add_child()
         else:
             root = self
+        ## debug
+        root.name = "root"
 
         if distribution == "fast":
             new_leaves = deque([root])
@@ -1252,12 +1254,18 @@ class TreeNode(object):
                         c.support = random.uniform(*support_range)
                 # else: DEFAULT_DIST and DEFAULT_SUPPORT values will be used
         elif distribution == "yule":
-            new_leaves = [root]
-            for _ in range(size - 1):
+            if size == 1:
+                new_leaves = [root]
+            elif size >= 2:
+                c1 = root.add_child()
+                c2 = root.add_child()
+                new_leaves = [c1, c2]
+            for _ in range(size - 2):
                 # choose random leaf
                 prev_leaf = random.choice(new_leaves)
 
                 if prev_leaf.up is None:
+                    "yule dist: leaf chosen with no parent!!!"
                     new_leaves.remove(prev_leaf)
                     # add two children to chosen leaf
                     c1 = prev_leaf.add_child()
@@ -1283,7 +1291,7 @@ class TreeNode(object):
             for _ in range(size - 1):
                 # choose random node to add new leaf as sister
                 grow_node = random.choice(new_nodes)
-                if grow_node.up is not None:
+                if grow_node != root:
                     # `grow_node` has a parent node
                     old_parent = grow_node.up
                     new_parent = old_parent.add_child()
@@ -1293,13 +1301,16 @@ class TreeNode(object):
                     new_leaf = new_parent.add_child()
                     # reassign root if necessary
                     if grow_node == root:
+                        ## debug
+                        print("Root reassignment triggered", grow_node)
                         root = new_parent
+                        root.name = "new root!"
                 else:
                     # `grow_node` is the root; sister has no parent
                     new_parent = NewNode()
                     if grow_node.is_leaf():
-                        new_leaves.append(new_parent)
                         new_leaves.remove(grow_node)
+                        new_leaves.append(new_parent)
                     for child in grow_node.get_children():
                         child.detach()
                         new_parent.add_child(child=child)
@@ -1339,6 +1350,8 @@ class TreeNode(object):
                     names_library.append(tname)
             else:
                 tname = ''.join(next(avail_names))
+            ## debug
+            if n.name != "": print(f"old leaf name {n.name} changed to {tname}")
             n.name = tname
 
     def set_outgroup(self, outgroup):

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1334,9 +1334,9 @@ class TreeNode(object):
         for n in new_leaves:
             if names_library is not None:
                 # choose next name
-                tname = names_library.pop()
+                tname = names_library.popleft()
                 if reuse_names:
-                    names_library.appendleft(tname)
+                    names_library.append(tname)
             else:
                 tname = ''.join(next(avail_names))
             n.name = tname

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1193,49 +1193,47 @@ class TreeNode(object):
         NewNode = self.__class__
 
         if len(self.children) > 1:
+            # add `connector` node between current node `self` and its children
             connector = NewNode()
-            for ch in self.get_children():
+            for ch in self.children:
                 ch.detach()
                 connector.add_child(child = ch)
-            root = NewNode()
             self.add_child(child = connector)
+            # add new `root` under `self` where additional nodes will populate a subtree
+            root = NewNode()
             self.add_child(child = root)
         else:
             root = self
 
-        next_deq = deque([root])
-        for i in range(size-1):
-            # choose a random leaf
-            p = random.choice(next_deq)
-            # remove chosen leaf
-            next_deq.remove(p)
+        new_leaves = [root]
+        for _ in range(size - 1):
+            # choose random leaf and remove it from `new_leaves` list
+            p = random.choice(new_leaves)
+            new_leaves.remove(p)
 
             # add two children to chosen leaf
             c1 = p.add_child()
             c2 = p.add_child()
-            # add new children to leaf deque
-            next_deq.extend([c1, c2])
+            # add new children to `new_leaves`
+            new_leaves.extend([c1, c2])
             if random_branches:
                 c1.dist = random.uniform(*branch_range)
                 c2.dist = random.uniform(*branch_range)
-                c1.support = random.uniform(*branch_range)
-                c2.support = random.uniform(*branch_range)
-            else:
-                c1.dist = 1.0
-                c2.dist = 1.0
-                c1.support = 1.0
-                c2.support = 1.0
+                c1.support = random.uniform(*support_range)
+                c2.support = random.uniform(*support_range)
+            # else: DEFAULT_DIST and DEFAULT_SUPPORT values will be used
 
         # next contains leaf nodes
         charset =  "abcdefghijklmnopqrstuvwxyz"
-        if names_library:
+        if names_library is not None:
             names_library = deque(names_library)
         else:
             avail_names = itertools.combinations_with_replacement(charset, 10)
-        # rearrange leaves in random order
-        next_deq = random.sample(next_deq, len(next_deq))
-        for n in next_deq:
-            if names_library:
+        # shuffle leaves in random order
+        random.shuffle(new_leaves)
+        # grow_leaves = random.sample(grow_leaves, len(grow_leaves))
+        for n in new_leaves:
+            if names_library is not None:
                 if reuse_names:
                     tname = names_library.pop()
                     names_library.appendleft(tname)

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1189,6 +1189,7 @@ class TreeNode(object):
           support values.
 
         """
+        print("using NEW VERSION")
         NewNode = self.__class__
 
         if len(self.children) > 1:
@@ -1242,23 +1243,6 @@ class TreeNode(object):
             else:
                 tname = ''.join(next(avail_names))
             n.name = tname
-
-        # next contains leaf nodes
-        charset =  "abcdefghijklmnopqrstuvwxyz"
-        if names_library:
-            names_library = deque(names_library)
-        else:
-            avail_names = itertools.combinations_with_replacement(charset, 10)
-        for n in next_deq:
-            if names_library:
-                if reuse_names:
-                    tname = random.sample(names_library, 1)[0]
-                else:
-                    tname = names_library.pop()
-            else:
-                tname = ''.join(next(avail_names))
-            n.name = tname
-
 
     def set_outgroup(self, outgroup):
         """

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1237,11 +1237,11 @@ class TreeNode(object):
         for n in next_deq:
             if names_library:
                 if reuse_names:
-                    tname = random.choice(names_library)
+                    tname = names_library.pop()
+                    names_library.appendleft(tname)
                 else:
-                    # choose random name
-                    tname = random.choice(names_library)
-                    names_library.remove(tname)
+                    # choose next name
+                    tname = names_library.pop()
             else:
                 tname = ''.join(next(avail_names))
             n.name = tname

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1204,13 +1204,15 @@ class TreeNode(object):
 
         next_deq = deque([root])
         for i in range(size-1):
-            if random.randint(0, 1):
-                p = next_deq.pop()
-            else:
-                p = next_deq.popleft()
+            # choose a random leaf
+            p = random.choice(next_deq)
+            # remove chosen leaf
+            next_deq.remove(p)
 
+            # add two children to chosen leaf
             c1 = p.add_child()
             c2 = p.add_child()
+            # add new children to leaf deque
             next_deq.extend([c1, c2])
             if random_branches:
                 c1.dist = random.uniform(*branch_range)
@@ -1222,6 +1224,24 @@ class TreeNode(object):
                 c2.dist = 1.0
                 c1.support = 1.0
                 c2.support = 1.0
+
+        # next contains leaf nodes
+        charset =  "abcdefghijklmnopqrstuvwxyz"
+        if names_library:
+            names_library = deque(names_library)
+        else:
+            avail_names = itertools.combinations_with_replacement(charset, 10)
+        for n in next_deq:
+            if names_library:
+                if reuse_names:
+                    tname = random.sample(names_library, 1)[0]
+                else:
+                    # choose random name
+                    tname = random.choice(names_library)
+                    names_library.remove(tname)
+            else:
+                tname = ''.join(next(avail_names))
+            n.name = tname
 
         # next contains leaf nodes
         charset =  "abcdefghijklmnopqrstuvwxyz"

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1168,7 +1168,7 @@ class TreeNode(object):
     def populate(self, size, names_library=None, reuse_names=False,
                  random_branches=False, branch_range=(0,1),
                  support_range=(0,1),
-                 topology="fast"):
+                 distribution="fast"):
         """
         Generates a random topology by populating current node.
 
@@ -1189,9 +1189,9 @@ class TreeNode(object):
           this range of values will be used to generate random branch
           support values.
 
-        :argument "fast" topology: Determines the algorithm used to place leaves which 
-          controls the resulting distribution over possible topologies. Parameter can be
-          "fast" (original implementation), "yule", or "pda" aka "uniform"
+        :argument "fast" distrubtion: Determines the algorithm used to place leaves,
+          which controls the resulting distribution over possible topologies. Parameter 
+          can be "fast" (original implementation), "yule", or "pda" aka "uniform"
         """
         print("using NEW VERSION")
         NewNode = self.__class__
@@ -1209,7 +1209,7 @@ class TreeNode(object):
         else:
             root = self
 
-        if topology == "fast":
+        if distribution == "fast":
             new_leaves = deque([root])
             for _ in range(size - 1):
                 if random.randint(0, 1):
@@ -1225,7 +1225,7 @@ class TreeNode(object):
                         c.dist = random.uniform(*branch_range)
                         c.support = random.uniform(*support_range)
                 # else: DEFAULT_DIST and DEFAULT_SUPPORT values will be used
-        elif topology == "yule":
+        elif distribution == "yule":
             new_leaves = [root]
             for _ in range(size - 1):
                 # choose random leaf and remove it from `new_leaves` list
@@ -1241,7 +1241,7 @@ class TreeNode(object):
                     for c in [c1, c2]:
                         c.dist = random.uniform(*branch_range)
                         c.support = random.uniform(*support_range)
-        elif topology == "pda" or topology == "uniform":
+        elif distribution == "pda" or distribution == "uniform":
             new_leaves = [root]
             new_nodes = [root]
             for i in range(size - 1):
@@ -1290,7 +1290,7 @@ class TreeNode(object):
                 # print("current nodes:", [x.name for x in new_nodes])
                 # print("current tree:", self.get_ascii())
         else:
-            raise ValueError(f"parameter topology={topology} not recognized")
+            raise ValueError(f"parameter topology={distribution} not recognized")
 
         # next contains leaf nodes
         charset =  "abcdefghijklmnopqrstuvwxyz"

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1250,13 +1250,12 @@ class TreeNode(object):
                 new_node = NewNode()
                 new_leaf = NewNode()
                 ## debugging
-                new_node.name = str(i) + "-node"
-                new_leaf.name = str(i) + "-leaf"
+                # new_node.name = str(i) + "-node"
+                # new_leaf.name = str(i) + "-leaf"
                 if sister.up is not None:
                     ## debug
-                    print("step", i, ": sister below root")
+                    # print("step", i, ": sister below root")
                     parent = sister.up
-                    assert parent is not None, (f"error: node={sister} has no parent")
                     parent.add_child(child=new_node)
                     sister.detach()
                     new_node.add_child(child=sister)
@@ -1264,18 +1263,18 @@ class TreeNode(object):
                     new_node.add_child(child=new_leaf)
                 else:
                     ## debug
-                    print("step", i, ": sister at root")
+                    # print("step", i, ": sister at root")
                     # sister is the root; sister has no parent
                     if len(sister.children) == 0:
                         new_leaves.append(new_node)
                         new_leaves.remove(sister)
                     else:
                         ## debug
-                        print("  current sister.children:", [x.name for x in sister.children])
+                        # print("  current sister.children:", [x.name for x in sister.children])
                         for child in sister.get_children():
                             child.detach()
                             new_node.add_child(child=child)
-                            print("  detached child", child.name)
+                            # print("  detached child", child.name)
                     sister.add_child(child=new_node)
                     sister.add_child(child=new_leaf)
                 
@@ -1287,9 +1286,9 @@ class TreeNode(object):
                         c.dist = random.uniform(*branch_range)
                         c.support = random.uniform(*support_range)
                 ## debug
-                print("current leaves:", [x.name for x in new_leaves])
-                print("current nodes:", [x.name for x in new_nodes])
-                print("current tree:", self.get_ascii())
+                # print("current leaves:", [x.name for x in new_leaves])
+                # print("current nodes:", [x.name for x in new_nodes])
+                # print("current tree:", self.get_ascii())
         else:
             raise ValueError(f"parameter topology={topology} not recognized")
 

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1168,7 +1168,7 @@ class TreeNode(object):
     def populate(self, size, names_library=None, reuse_names=False,
                  random_branches=False, branch_range=(0,1),
                  support_range=(0,1),
-                 distribution="fast"):
+                 distribution="fast", ladderize=True):
         """
         Generates a random topology by populating current node.
 
@@ -1192,6 +1192,8 @@ class TreeNode(object):
         :argument "fast" distrubtion: Determines the algorithm used to place leaves,
           which controls the resulting distribution over possible topologies. Parameter 
           can be "fast" (original implementation), "yule", or "pda" aka "uniform"
+
+        :argument True ladderize: If True, resulting tree is ladderized
         """
         print("using NEW VERSION")
         NewNode = self.__class__
@@ -1249,12 +1251,7 @@ class TreeNode(object):
                 sister = random.choice(new_nodes)
                 new_node = NewNode()
                 new_leaf = NewNode()
-                ## debugging
-                # new_node.name = str(i) + "-node"
-                # new_leaf.name = str(i) + "-leaf"
                 if sister.up is not None:
-                    ## debug
-                    # print("step", i, ": sister below root")
                     parent = sister.up
                     parent.add_child(child=new_node)
                     sister.detach()
@@ -1262,19 +1259,14 @@ class TreeNode(object):
                     # add child to new_node
                     new_node.add_child(child=new_leaf)
                 else:
-                    ## debug
-                    # print("step", i, ": sister at root")
                     # sister is the root; sister has no parent
                     if len(sister.children) == 0:
                         new_leaves.append(new_node)
                         new_leaves.remove(sister)
                     else:
-                        ## debug
-                        # print("  current sister.children:", [x.name for x in sister.children])
                         for child in sister.get_children():
                             child.detach()
                             new_node.add_child(child=child)
-                            # print("  detached child", child.name)
                     sister.add_child(child=new_node)
                     sister.add_child(child=new_leaf)
                 
@@ -1285,14 +1277,10 @@ class TreeNode(object):
                     for c in [new_node, new_leaf]:
                         c.dist = random.uniform(*branch_range)
                         c.support = random.uniform(*support_range)
-                ## debug
-                # print("current leaves:", [x.name for x in new_leaves])
-                # print("current nodes:", [x.name for x in new_nodes])
-                # print("current tree:", self.get_ascii())
         else:
             raise ValueError(f"parameter topology={distribution} not recognized")
 
-        # next contains leaf nodes
+        # new_leaves contains leaf nodes which need names
         charset =  "abcdefghijklmnopqrstuvwxyz"
         if names_library is not None:
             names_library = deque(names_library)
@@ -1309,6 +1297,8 @@ class TreeNode(object):
             else:
                 tname = ''.join(next(avail_names))
             n.name = tname
+        if ladderize:
+            self.ladderize()
 
     def set_outgroup(self, outgroup):
         """

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1234,8 +1234,6 @@ class TreeNode(object):
             root = self.add_child()
         else:
             root = self
-        ## debug
-        root.name = "root"
 
         if distribution == "fast":
             new_leaves = deque([root])
@@ -1264,23 +1262,14 @@ class TreeNode(object):
                 # choose random leaf
                 prev_leaf = random.choice(new_leaves)
 
-                if prev_leaf.up is None:
-                    "yule dist: leaf chosen with no parent!!!"
-                    new_leaves.remove(prev_leaf)
-                    # add two children to chosen leaf
-                    c1 = prev_leaf.add_child()
-                    c2 = prev_leaf.add_child()
-                    # add new children to `new_leaves`
-                    new_leaves.extend([c1, c2])
-                else:
-                    old_parent = prev_leaf.up
-                    # new internal node below `old_parent`
-                    new_parent = old_parent.add_child()
-                    new_leaf = new_parent.add_child()
-                    prev_leaf.detach()
-                    new_parent.add_child(child=prev_leaf)
-                    new_leaves.append(new_leaf)
-                    c1, c2 = new_leaf, new_parent
+                old_parent = prev_leaf.up
+                # new internal node below `old_parent`
+                new_parent = old_parent.add_child()
+                new_leaf = new_parent.add_child()
+                prev_leaf.detach()
+                new_parent.add_child(child=prev_leaf)
+                new_leaves.append(new_leaf)
+                c1, c2 = new_leaf, new_parent
                 if random_branches:
                     for c in [c1, c2]:
                         c.dist = random.uniform(*branch_range)
@@ -1299,12 +1288,6 @@ class TreeNode(object):
                     new_parent.add_child(child=grow_node)
                     # add child to new_node
                     new_leaf = new_parent.add_child()
-                    # reassign root if necessary
-                    if grow_node == root:
-                        ## debug
-                        print("Root reassignment triggered", grow_node)
-                        root = new_parent
-                        root.name = "new root!"
                 else:
                     # `grow_node` is the root; sister has no parent
                     new_parent = NewNode()
@@ -1335,13 +1318,9 @@ class TreeNode(object):
         else:
             charset =  "abcdefghijklmnopqrstuvwxyz"
             avail_names = itertools.combinations_with_replacement(charset, 10)
-        # ## debug
-        # print("new leaves:", new_leaves)
         if distribution != "fast":
             # shuffle `new_leaves` in random order
             random.shuffle(new_leaves)
-        # ## debug
-        # print("shuffled leaves:", new_leaves)
         for n in new_leaves:
             if names_library is not None:
                 # choose next name
@@ -1350,8 +1329,6 @@ class TreeNode(object):
                     names_library.append(tname)
             else:
                 tname = ''.join(next(avail_names))
-            ## debug
-            if n.name != "": print(f"old leaf name {n.name} changed to {tname}")
             n.name = tname
 
     def set_outgroup(self, outgroup):

--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -1232,10 +1232,12 @@ class TreeNode(object):
             names_library = deque(names_library)
         else:
             avail_names = itertools.combinations_with_replacement(charset, 10)
+        # rearrange leaves in random order
+        next_deq = random.sample(next_deq, len(next_deq))
         for n in next_deq:
             if names_library:
                 if reuse_names:
-                    tname = random.sample(names_library, 1)[0]
+                    tname = random.choice(names_library)
                 else:
                     # choose random name
                     tname = random.choice(names_library)


### PR DESCRIPTION
The `populate` method is modified to have an additional `distribution` argument, which can select from three possible options:

* `distribution="fast"`: populates a subtree using the previous algorithm.
* `distribution="yule"`: populate a subtree according to the Yule distribution.
* `distribution="uniform"` or `distribution="pda"`: populate a subtree according to the uniform or PDA (proportional to distinguishable arrangements) distribution.

These distributions are defined in Semple and Steel, [Phylogenetics](https://global.oup.com/academic/product/phylogenetics-9780198509424), Chapter 2.5.

This pull request also adds the following features to the `populate` method:

* The newly-generated subtree is ladderized. This behavior can be controlled with the `ladderize` boolean keyword argument, with default value `True`.
* There is an optional `seed` keyword argument, which can be used to control the random behavior of subtree generation if desired.

Closes #691 