### PR TITLE
Ete4 gtdb

### DIFF
--- a/ete4/gtdb_taxonomy/gtdbquery.py
+++ b/ete4/gtdb_taxonomy/gtdbquery.py
@@ -21,7 +21,7 @@ __all__ = ["GTDBTaxa", "is_taxadb_up_to_date"]
 
 DB_VERSION = 2
 DEFAULT_GTDBTAXADB = ETE_DATA_HOME + '/gtdbtaxa.sqlite'
-DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdbdump.tar.gz' # latest
+DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdbdump.tar.gz'
 
 
 def is_taxadb_up_to_date(dbfile=DEFAULT_GTDBTAXADB):
@@ -63,7 +63,6 @@ class GTDBTaxa:
             urlbase = ('https://github.com/etetoolkit/ete-data/raw/main'
                        '/gtdb_taxonomy/gtdblatest')
             
-            #update_ete_data(f'{DEFAULT_GTDBTAXADB}.traverse.pkl', f'{urlbase}/gtdbtaxa.sqlite.traverse.pkl')
             update_ete_data(f'{DEFAULT_GTDBTAXADUMP}', f'{urlbase}/gtdbdump.tar.gz')
 
             self.update_taxonomy_database(taxdump_file=DEFAULT_GTDBTAXADUMP)
@@ -755,12 +754,8 @@ def update_db(dbfile, targz_file=None):
     basepath = os.path.split(dbfile)[0]
     if basepath and not os.path.exists(basepath):
         os.mkdir(basepath)
-
-    # try:
-    #     tar = tarfile.open(targz_file, 'r')
-    # except:
-    #     raise ValueError("Please provide taxa dump tar.gz file")
-
+    
+    # if users don't provie targz_file, update the latest version from ete-data 
     if not targz_file:
         update_local_taxdump(DEFAULT_GTDBTAXADUMP)
         targz_file = DEFAULT_GTDBTAXADUMP

--- a/ete4/gtdb_taxonomy/gtdbquery.py
+++ b/ete4/gtdb_taxonomy/gtdbquery.py
@@ -23,7 +23,6 @@ DB_VERSION = 2
 DEFAULT_GTDBTAXADB = ETE_DATA_HOME + '/gtdbtaxa.sqlite'
 DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdbdump.tar.gz'
 
-
 def is_taxadb_up_to_date(dbfile=DEFAULT_GTDBTAXADB):
     """Check if a valid and up-to-date gtdbtaxa.sqlite database exists
     If dbfile= is not specified, DEFAULT_TAXADB is assumed
@@ -63,7 +62,7 @@ class GTDBTaxa:
             urlbase = ('https://github.com/etetoolkit/ete-data/raw/main'
                        '/gtdb_taxonomy/gtdblatest')
             
-            update_ete_data(f'{DEFAULT_GTDBTAXADUMP}', f'{urlbase}/gtdbdump.tar.gz')
+            update_ete_data(f'{DEFAULT_GTDBTAXADUMP}', f'{urlbase}/gtdb_latest_dump.tar.gz')
 
             self.update_taxonomy_database(taxdump_file=DEFAULT_GTDBTAXADUMP)
 
@@ -776,8 +775,9 @@ def update_db(dbfile, targz_file=None):
     os.system("rm taxa.tab")
 
 def update_local_taxdump(fname=DEFAULT_GTDBTAXADUMP):
-    url = "https://github.com/etetoolkit/ete-data/raw/main/gtdb_taxonomy/gtdblatest/gtdbdump.tar.gz"
-
+    # latest version of gtdb taxonomy dump
+    url = "https://github.com/etetoolkit/ete-data/raw/main/gtdb_taxonomy/gtdblatest/gtdb_latest_dump.tar.gz"
+    
     if not os.path.exists(fname):
         print(f'Downloading {fname} from {url} ...')
         with open(fname, 'wb') as f:

--- a/ete4/gtdb_taxonomy/gtdbquery.py
+++ b/ete4/gtdb_taxonomy/gtdbquery.py
@@ -12,6 +12,7 @@ import sqlite3
 import math
 import tarfile
 import warnings
+import requests
 
 from ete4 import ETE_DATA_HOME, update_ete_data
 
@@ -20,7 +21,7 @@ __all__ = ["GTDBTaxa", "is_taxadb_up_to_date"]
 
 DB_VERSION = 2
 DEFAULT_GTDBTAXADB = ETE_DATA_HOME + '/gtdbtaxa.sqlite'
-DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdb202dump.tar.gz'
+DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdbdump.tar.gz' # latest
 
 
 def is_taxadb_up_to_date(dbfile=DEFAULT_GTDBTAXADB):
@@ -60,9 +61,10 @@ class GTDBTaxa:
         if dbfile != DEFAULT_GTDBTAXADB and not os.path.exists(self.dbfile):
             print('GTDB database not present yet (first time used?)', file=sys.stderr)
             urlbase = ('https://github.com/etetoolkit/ete-data/raw/main'
-                       '/gtdb_taxonomy/gtdb202')
-            update_ete_data(f'{DEFAULT_GTDBTAXADB}.traverse.pkl', f'{urlbase}/gtdbtaxa.sqlite.traverse.pkl')
-            update_ete_data(f'{DEFAULT_GTDBTAXADUMP}', f'{urlbase}/gtdb202dump.tar.gz')
+                       '/gtdb_taxonomy/gtdblatest')
+            
+            #update_ete_data(f'{DEFAULT_GTDBTAXADB}.traverse.pkl', f'{urlbase}/gtdbtaxa.sqlite.traverse.pkl')
+            update_ete_data(f'{DEFAULT_GTDBTAXADUMP}', f'{urlbase}/gtdbdump.tar.gz')
 
             self.update_taxonomy_database(taxdump_file=DEFAULT_GTDBTAXADUMP)
 
@@ -754,11 +756,16 @@ def update_db(dbfile, targz_file=None):
     if basepath and not os.path.exists(basepath):
         os.mkdir(basepath)
 
-    try:
-        tar = tarfile.open(targz_file, 'r')
-    except:
-        raise ValueError("Please provide taxa dump tar.gz file")
+    # try:
+    #     tar = tarfile.open(targz_file, 'r')
+    # except:
+    #     raise ValueError("Please provide taxa dump tar.gz file")
 
+    if not targz_file:
+        update_local_taxdump(DEFAULT_GTDBTAXADUMP)
+        targz_file = DEFAULT_GTDBTAXADUMP
+    
+    tar = tarfile.open(targz_file, 'r')
     t, synonyms = load_gtdb_tree_from_dump(tar)
 
     prepostorder = [int(node.name) for post, node in t.iter_prepostorder()]
@@ -772,6 +779,24 @@ def update_db(dbfile, targz_file=None):
     upload_data(dbfile)
 
     os.system("rm taxa.tab")
+
+def update_local_taxdump(fname=DEFAULT_GTDBTAXADUMP):
+    url = "https://github.com/etetoolkit/ete-data/raw/main/gtdb_taxonomy/gtdblatest/gtdbdump.tar.gz"
+
+    if not os.path.exists(fname):
+        print(f'Downloading {fname} from {url} ...')
+        with open(fname, 'wb') as f:
+            f.write(requests.get(url).content)
+    else:
+        md5_local = md5(open(fname, 'rb').read()).hexdigest()
+        md5_remote = requests.get(url + '.md5').text.split()[0]
+
+        if md5_local != md5_remote:
+            print(f'Updating {fname} from {url} ...')
+            with open(fname, 'wb') as f:
+                f.write(requests.get(url).content)
+        else:
+            print(f'File {fname} is already up-to-date with {url} .')
 
 def upload_data(dbfile):
     print()

--- a/tests/test_gtdbquery.py
+++ b/tests/test_gtdbquery.py
@@ -3,9 +3,10 @@ import unittest
 
 from ete4 import PhyloTree, GTDBTaxa, ETE_DATA_HOME, update_ete_data
 from ete4.gtdb_taxonomy import gtdbquery
+import requests
 
 DATABASE_PATH = ETE_DATA_HOME + '/gtdbtaxa.sqlite'
-DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdb202dump.tar.gz'
+DEFAULT_GTDBTAXADUMP = ETE_DATA_HOME + '/gtdbdump.tar.gz'
 
 
 class Test_gtdbquery(unittest.TestCase):
@@ -13,10 +14,15 @@ class Test_gtdbquery(unittest.TestCase):
     def test_00_update_database(self):
         gtdb = GTDBTaxa()
 
-        if not os.path.exists(DEFAULT_GTDBTAXADUMP):
-            url = ('https://github.com/etetoolkit/ete-data/raw/main'
+        url = ('https://github.com/etetoolkit/ete-data/raw/main'
                    '/gtdb_taxonomy/gtdb202/gtdb202dump.tar.gz')
-            update_ete_data(DEFAULT_GTDBTAXADUMP, url)
+        
+        print(f'updating GTDB database release 202 from {url} for testing ...')
+        print(f'Downloading {DEFAULT_GTDBTAXADUMP} from {url} ...')
+
+        with open(DEFAULT_GTDBTAXADUMP, 'wb') as f:
+            f.write(requests.get(url).content)
+
         gtdb.update_taxonomy_database(DEFAULT_GTDBTAXADUMP)
 
         if not os.path.exists(DATABASE_PATH):
@@ -81,6 +87,6 @@ class Test_gtdbquery(unittest.TestCase):
         self.assertEqual(out[0]['o__Peptococcales'],
                          ['root', 'd__Bacteria', 'p__Firmicutes_B', 'c__Peptococcia', 'o__Peptococcales'])
 
-
+#Test_gtdbquery()
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gtdbquery.py
+++ b/tests/test_gtdbquery.py
@@ -17,8 +17,7 @@ class Test_gtdbquery(unittest.TestCase):
         url = ('https://github.com/etetoolkit/ete-data/raw/main'
                    '/gtdb_taxonomy/gtdb202/gtdb202dump.tar.gz')
         
-        print(f'updating GTDB database release 202 from {url} for testing ...')
-        print(f'Downloading {DEFAULT_GTDBTAXADUMP} from {url} ...')
+        print(f'Downloading GTDB database release 202 to {DEFAULT_GTDBTAXADUMP} from {url}')
 
         with open(DEFAULT_GTDBTAXADUMP, 'wb') as f:
             f.write(requests.get(url).content)
@@ -87,6 +86,5 @@ class Test_gtdbquery(unittest.TestCase):
         self.assertEqual(out[0]['o__Peptococcales'],
                          ['root', 'd__Bacteria', 'p__Firmicutes_B', 'c__Peptococcia', 'o__Peptococcales'])
 
-#Test_gtdbquery()
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
as GTDB datbase create the release of latest version(https://data.gtdb.ecogenomic.org/releases/latest/), which allows us to defaulty update to the latest without specifically choosing the release version, the GTDBTaxa() module also adopt this feature. And still maintain the option of updating cusomize different releases dump file

 