### PR TITLE
Lift `sqlite3`'s `check_same_thread` flag to `NCBITaxa.__init__()`

### DIFF
--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -45,7 +45,7 @@ class NCBITaxa:
     """
 
     def __init__(self, dbfile=None, taxdump_file=None,
-                 memory=False, update=True):
+                 memory=False, update=True, check_same_thread=True):
         """Open and keep a connection to the NCBI taxonomy database.
 
         If it is not present in the system, it will download the
@@ -53,6 +53,7 @@ class NCBITaxa:
         format.
         """
         self.dbfile = dbfile or DEFAULT_TAXADB
+        self.check_same_thread = check_same_thread
 
         if taxdump_file:
             self.update_taxonomy_database(taxdump_file)
@@ -90,7 +91,7 @@ class NCBITaxa:
         update_db(self.dbfile, taxdump_file)
 
     def _connect(self):
-        self.db = sqlite3.connect(self.dbfile)
+        self.db = sqlite3.connect(self.dbfile, self.check_same_thread)
 
     def _translate_merged(self, all_taxids):
         conv_all_taxids = set((list(map(int, all_taxids))))


### PR DESCRIPTION
Using this object in a multithreaded environment ( ex. `concurrent.futures`) results in the following error:  `SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 131662279252864 and this is thread id 131661501028032.`

Perhaps this is to be expected of sqlite, but given that the taxonomy db itself is readonly ( i assume?) after creation, i think this flag should be exposed.