### PR TITLE
Workaround `cgi` removal in Python3.13

### DIFF
--- a/ete3/__init__.py
+++ b/ete3/__init__.py
@@ -55,7 +55,7 @@ from .phylo.phylotree import *
 from .evol.evoltree import *
 try:
     from .webplugin.webapp import *
-except ImportError as e:
+except (ModuleNotFoundError, ImportError) as e:
     warn("web plugin not available for Python >= 3.13")
 from .phyloxml import Phyloxml, PhyloxmlTree
 from .nexml import Nexml, NexmlTree

--- a/ete3/__init__.py
+++ b/ete3/__init__.py
@@ -53,7 +53,10 @@ from .coretype.tree import *
 from .coretype.seqgroup import *
 from .phylo.phylotree import *
 from .evol.evoltree import *
-from .webplugin.webapp import *
+try:
+    from .webplugin.webapp import *
+except ImportError as e:
+    warn("web plugin not available for Python >= 3.13")
 from .phyloxml import Phyloxml, PhyloxmlTree
 from .nexml import Nexml, NexmlTree
 from .evol import EvolTree

--- a/ete3/__init__.py
+++ b/ete3/__init__.py
@@ -56,7 +56,7 @@ from .evol.evoltree import *
 try:
     from .webplugin.webapp import *
 except (ModuleNotFoundError, ImportError) as e:
-    warn("web plugin not available for Python >= 3.13")
+    warn("ete web plugin not available for Python >= 3.13")
 from .phyloxml import Phyloxml, PhyloxmlTree
 from .nexml import Nexml, NexmlTree
 from .evol import EvolTree


### PR DESCRIPTION
Currently, importing `ete3` in Python3.13 fails due to the [standard library `cgi` module having been removed](https://docs.python.org/3/library/cgi.html).
```
Python 3.13.1 (main, Dec  9 2024, 00:00:00) [GCC 14.2.1 20240912 (Red Hat 14.2.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ete3
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import ete3
  File "/home/mmore500/.local/lib/python3.13/site-packages/ete3/__init__.py", line 56, in <module>
    from .webplugin.webapp import *
  File "/home/mmore500/.local/lib/python3.13/site-packages/ete3/webplugin/webapp.py", line 44, in <module>
    import cgi
ModuleNotFoundError: No module named 'cgi'
```

As a temporary solution, this pull request patches `ete3/__init__.py` to catch the generated `ModuleNotFoundError` and warn the user that webapp support is not available in Python3.13.