### PR TITLE
Fix issues when installing ete4 on Windows.

### DIFF
--- a/ete4/config.py
+++ b/ete4/config.py
@@ -11,7 +11,7 @@ import requests
 
 # Helper function to define global ETE_* variables.
 def ete_path(xdg_var, default):
-    return os.environ.get(xdg_var, os.environ['HOME'] + default) + '/ete'
+    return os.environ.get(xdg_var, os.path.expanduser('~') + default) + '/ete'
 
 ETE_DATA_HOME   = ete_path('XDG_DATA_HOME',   '/.local/share')
 ETE_CONFIG_HOME = ete_path('XDG_CONFIG_HOME', '/.config')

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, Extension
 
 from glob import glob
-from os.path import isfile
+from os.path import isfile, sep
 
 from Cython.Build import cythonize
 
 
 def make_extension(path):  # to create cython extensions the way we want
-    name = path.replace('/', '.')[:-len('.pyx')]  # / -> .  and remove .pyx
+    name = path.replace(sep, '.')[:-len('.pyx')]  # / -> .  and remove .pyx
     return Extension(name, [path], extra_compile_args=['-O3'])
 
 setup(


### PR DESCRIPTION
Hi,

I am using GitHub Actions to test tools on Windows. Since I have modified these tools to use ete4, there is an issue with the Windows build when it tries to install ete4 using pip (error encountered with ete4 4.1.1 and 4.3.0). It happens during the compilation by Cython of ete4. But it is not happening with Ubuntu or macOS builds.

You can find a full traceback of this error [here](https://github.com/AuReMe/metage2metabo/actions/runs/15064981851/job/42347705202).

After several tests, I found that the error comes from the separator used in the `setup.py` file:
https://github.com/etetoolkit/ete/blob/ete4/setup.py#L10

Indeed, the `/` works for Ubuntu and macOS, but for Windows it is not correct and leads to errors. So I created this PR to fix this and use `os.path.sep` instead to specify the path separator and to have the correct one for Windows.

Also, I implement the fix proposed in https://github.com/etetoolkit/ete/issues/763, to solve KeyError issue on Windows.

With these two changes, ete4 was installed correctly on Windows, on different runs:
https://github.com/AuReMe/metage2metabo/actions/runs/15068672311
https://github.com/AuReMe/emapper2gbk/actions/runs/15069612333

Best regards,
Arnaud Belcour.