### PR TITLE
Allow rgba colors

### DIFF
--- a/ete4/treeview/main.py
+++ b/ete4/treeview/main.py
@@ -17,7 +17,7 @@ def tracktime(f):
 
 _LINE_TYPE_CHECKER = lambda x: x in (0, 1, 2)
 _SIZE_CHECKER = lambda x: isinstance(x, int)
-_COLOR_MATCH = re.compile(r"^#[A-Fa-f\d]{6}$")
+_COLOR_MATCH = re.compile(r"^#[A-Fa-f\d]{6,8}$")
 _COLOR_CHECKER = lambda x: x.lower() in SVG_COLORS or re.match(_COLOR_MATCH, x)
 _NODE_TYPE_CHECKER = lambda x: x in ["sphere", "circle", "square"]
 _BOOL_CHECKER = lambda x: isinstance(x, bool) or x in (0, 1)


### PR DESCRIPTION
QT also supports colors in the ARGB format: https://doc.qt.io/qtforpython-6/PySide6/QtGui/QColor.html#detailed-description Unfortunately, the only thing that prevents people from utilizing this feature is the valdation of hexadecimal colors.

My specific use-case is decreasing the opacity of the background color of leaf nodes. Currently, there is no other way to do this. However, the border color doesn't change. Any help with this would be highly apprechiated. 