### PR TITLE
Fix: handle `pack_leaves` when adjusting circle rect size

### DIFF
--- a/ete4/treeview/qt_render.py
+++ b/ete4/treeview/qt_render.py
@@ -268,7 +268,7 @@ def render(root_node, img, hide_root=False):
         full_circle_area = (tree_radius * 2) ** 2
         cropped_area = (max_x - min_x) * (max_y - min_y)
 
-        if arc_span < 359 and (cropped_area / full_circle_area) < 0.75:
+        if arc_span < 359 and (cropped_area / full_circle_area) < 0.75 and img.pack_leaves:
             mainRect.adjust(min_x, min_y, max_x, max_y)
         else:
             mainRect.adjust(-tree_radius, -tree_radius, tree_radius, tree_radius)


### PR DESCRIPTION
I opened an issue at #805 because switching to ete4 regressed my trees. This was due to a `pack_leaves` option added. The `pack_leaves` parameter did not control whether the mainRect was adjusted or not on `line 271`. I propose adding it to the if-else statement. This fixes my issue and, I think, still maintains the usability of the `pack_leaves` feature.
