### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/ete3/coretype/tree.py
+++ b/ete3/coretype/tree.py
@@ -362,7 +362,7 @@ class TreeNode(object):
             return self.up.remove_child(sister)
 
     def delete(self, prevent_nondicotomic=True, preserve_branch_length=False):
-        """
+        r"""
         Deletes node from the tree structure. Notice that this method
         makes 'disappear' the node from the tree structure. This means
         that children from the deleted node are transferred to the
@@ -433,7 +433,7 @@ class TreeNode(object):
 
 
     def prune(self, nodes, preserve_branch_length=False):
-        """Prunes the topology of a node to conserve only the selected list of leaf
+        r"""Prunes the topology of a node to conserve only the selected list of leaf
         internal nodes. The minimum number of nodes that conserve the
         topological relationships among the requested nodes will be
         retained. Root node is always conserved.
@@ -1487,7 +1487,7 @@ class TreeNode(object):
                                       units=units, dpi=dpi)
 
     def copy(self, method="cpickle"):
-        """.. versionadded: 2.1
+        r""".. versionadded: 2.1
 
         Returns a copy of the current node.
 

--- a/ete3/evol/evoltree.py
+++ b/ete3/evol/evoltree.py
@@ -465,10 +465,10 @@ class EvolNode(PhyloNode):
         from re import sub
         if int(format) == 11:
             nwk = ' %s 1\n' % (len(self))
-            nwk += sub('\[&&NHX:mark=([ #0-9.]*)\]', r'\1',
+            nwk += sub(r'\[&&NHX:mark=([ #0-9.]*)\]', r'\1',
                        write_newick(self, features=['mark'], format=9))
         elif int(format) == 10:
-            nwk = sub('\[&&NHX:mark=([ #0-9.]*)\]', r'\1',
+            nwk = sub(r'\[&&NHX:mark=([ #0-9.]*)\]', r'\1',
                       write_newick(self, features=['mark'], format=9))
         else:
             nwk = write_newick(self, features=features, format=format)

--- a/ete3/evol/model.py
+++ b/ete3/evol/model.py
@@ -364,8 +364,8 @@ def check_name(model):
     '''
     check that model name corresponds to one of the available
     '''
-    if sub('\..*', '', model) in AVAIL:
-        return model, AVAIL [sub('\..*', '', model)]
+    if sub(r'\..*', '', model) in AVAIL:
+        return model, AVAIL [sub(r'\..*', '', model)]
 
 
 

--- a/ete3/evol/parser/codemlparser.py
+++ b/ete3/evol/parser/codemlparser.py
@@ -71,25 +71,25 @@ def parse_rst(path):
     for line in open(path):
         # get number of classes of sites
         if line.startswith ('dN/dS '):
-            k = int(re.sub ('.* \(K=([0-9]+)\)\n', '\\1', line))
+            k = int(re.sub (r'.* \(K=([0-9]+)\)\n', r'\1', line))
             continue
         # get values of omega and proportions
         if typ is None and \
-           re.match ('^[a-z]+.*(\d+\.\d{5} *){'+ str(k) +'}', line):
+           re.match (r'^[a-z]+.*(\d+\.\d{5} *){'+ str(k) +'}', line):
             var = re.sub (':', '', line.split('  ')[0])
             if var.startswith ('p'):
                 var = 'proportions'
-            classes[var] = [float(v) for v in re.findall('\d+\.\d{5}', line)]
+            classes[var] = [float(v) for v in re.findall(r'\d+\.\d{5}', line)]
             continue
         # parse NEB and BEB tables
         if '(BEB)' in line :
-            k = int(re.sub('.*for (\d+) classes.*\n', '\\1', line))
+            k = int(re.sub(r'.*for (\d+) classes.*\n', r'\1', line))
             typ = 'BEB'
             sites[typ] = {}
             n_classes[typ] = k
             continue
         if '(NEB)' in line :
-            k = int(re.sub('.*for (\d+) classes.*\n', '\\1', line))
+            k = int(re.sub(r'.*for (\d+) classes.*\n', r'\1', line))
             typ = 'NEB'
             sites[typ] = {}
             n_classes[typ] = k
@@ -214,7 +214,7 @@ def parse_paml (pamout, model):
     # if we do not have tree, load it
     if model._tree is None:
         from ..evol import EvolTree
-        model._tree = EvolTree (re.findall ('\(.*\);', ''.join(all_lines))[2])
+        model._tree = EvolTree (re.findall (r'\(.*\);', ''.join(all_lines))[2])
         model._tree._label_as_paml()
     # starts parsing
     for i, line in enumerate (all_lines):
@@ -224,7 +224,7 @@ def parse_paml (pamout, model):
         if line.startswith('Codon frequencies under model'):
             model.stats ['codonFreq'] = []
             for j in range (16):
-                line = list(map (float, re.findall ('\d\.\d+', all_lines [i+j+1])))
+                line = list(map (float, re.findall (r'\d\.\d+', all_lines [i+j+1])))
                 model.stats ['codonFreq'] += [line]
             continue
         if line.startswith('Nei & Gojobori 1986'):
@@ -237,32 +237,32 @@ def parse_paml (pamout, model):
         # lnL and number of parameters
         if line.startswith ('lnL'):
             try:
-                line = re.sub ('.* np: *(\d+)\): +(-\d+\.\d+).*',
-                               '\\1 \\2', line)
+                line = re.sub (r'.* np: *(\d+)\): +(-\d+\.\d+).*',
+                               r'\1 \2', line)
                 model.stats ['np' ] = int   (line.split()[0])
                 model.stats ['lnL'] = float (line.split()[1])
             except ValueError:
-                line = re.sub ('.* np: *(\d+)\): +(nan).*',
-                               '\\1 \\2', line)
+                line = re.sub (r'.* np: *(\d+)\): +(nan).*',
+                               r'\1 \2', line)
                 model.stats ['np' ] = int   (line.split()[0])
                 model.stats ['lnL'] = float ('-inf')
             continue
         # get labels of internal branches
         if line.count('..') >= 2:
-            labels = re.findall ('\d+\.\.\d+', line + ' ')
+            labels = re.findall (r'\d+\.\.\d+', line + ' ')
             _check_paml_labels (model._tree, labels, pamout, model)
             continue
         # retrieve kappa
         if line.startswith ('kappa '):
             try:
-                model.stats ['kappa'] = float (re.sub ('.*(\d+\.\d+).*',
-                                                       '\\1', line))
+                model.stats ['kappa'] = float (re.sub (r'.*(\d+\.\d+).*',
+                                                       r'\1', line))
             except ValueError:
                 model.stats ['kappa'] = 'nan'
         # retrieve dS dN t w N S and if present, errors. from summary table
         if line.count('..') == 1 and line.startswith (' '):
-            if not re.match (' +\d+\.\.\d+ +\d+\.\d+ ', line):
-                if re.match (' +( +\d+\.\d+){8}', all_lines [i+1]):
+            if not re.match (r' +\d+\.\.\d+ +\d+\.\d+ ', line):
+                if re.match (r' +( +\d+\.\d+){8}', all_lines [i+1]):
                     _get_values (model, line.split ()[0]+'  '+all_lines [i+1])
                 continue
             _get_values (model, line)

--- a/ete3/parser/newick.py
+++ b/ete3/parser/newick.py
@@ -48,11 +48,11 @@ __all__ = ["read_newick", "write_newick", "print_supported_formats"]
 ITERABLE_TYPES = set([list, set, tuple, frozenset])
 
 # Regular expressions used for reading newick format
-_ILEGAL_NEWICK_CHARS = ":;(),\[\]\t\n\r="
+_ILEGAL_NEWICK_CHARS = ":;(),\\[\\]\t\n\r="
 _NON_PRINTABLE_CHARS_RE = "[\x00-\x1f]+"
 
-_NHX_RE = "\[&&NHX:[^\]]*\]"
-_FLOAT_RE = "\s*[+-]?\d+\.?\d*(?:[eE][-+]?\d+)?\s*"
+_NHX_RE = r"\[&&NHX:[^\]]*\]"
+_FLOAT_RE = r"\s*[+-]?\d+\.?\d*(?:[eE][-+]?\d+)?\s*"
 #_FLOAT_RE = "[+-]?\d+\.?\d*"
 #_NAME_RE = "[^():,;\[\]]+"
 _NAME_RE = "[^():,;]+?"
@@ -399,7 +399,7 @@ def compile_matchers(formatcode):
             SECOND_MATCH += "?"
 
 
-        matcher_str= '^\s*%s\s*%s\s*(%s)?\s*$' % (FIRST_MATCH, SECOND_MATCH, _NHX_RE)
+        matcher_str= r'^\s*%s\s*%s\s*(%s)?\s*$' % (FIRST_MATCH, SECOND_MATCH, _NHX_RE)
         compiled_matcher = re.compile(matcher_str)
         matchers[node_type] = [container1, container2, converterFn1, converterFn2, compiled_matcher]
 

--- a/ete3/parser/phylip.py
+++ b/ete3/parser/phylip.py
@@ -73,7 +73,7 @@ def read_phylip(source, interleaved=True, obj=None,
             continue
         # Reads head
         if not nchar or not ntax:
-            m = re.match("^\s*(\d+)\s+(\d+)",line)
+            m = re.match(r"^\s*(\d+)\s+(\d+)",line)
             if m:
                 ntax  = int (m.groups()[0])
                 nchar = int (m.groups()[1])
@@ -105,7 +105,7 @@ def read_phylip(source, interleaved=True, obj=None,
                         line = m.groups()[1]
                     else:
                         raise Exception("Wrong phylip sequencial format.")
-                SG.id2seq[id_counter] += re.sub("\s","", line)
+                SG.id2seq[id_counter] += re.sub(r"\s","", line)
                 if len(SG.id2seq[id_counter]) == nchar:
                     id_counter += 1
                     name = None
@@ -120,7 +120,7 @@ def read_phylip(source, interleaved=True, obj=None,
                     if m:
                         name = m.groups()[0].strip()
 
-                        seq = re.sub("\s","",m.groups()[1])
+                        seq = re.sub(r"\s","",m.groups()[1])
                         SG.id2seq[id_counter] = seq
                         SG.id2name[id_counter] = name
                         if fix_duplicates and name in SG.name2id:
@@ -135,7 +135,7 @@ def read_phylip(source, interleaved=True, obj=None,
                     else:
                         raise Exception("Unexpected number of sequences.")
                 else:
-                    seq = re.sub("\s", "", line)
+                    seq = re.sub(r"\s", "", line)
                     if id_counter == len(SG):
                         id_counter = 0
                     SG.id2seq[id_counter] += seq

--- a/ete3/phylo/phylotree.py
+++ b/ete3/phylo/phylotree.py
@@ -129,7 +129,7 @@ def _get_subtrees(tree, full_copy=False, features=None, newick_only=False):
         return ''.join([pre, node.name, fstring, post])
 
     if newick_only:
-        id_match = re.compile("([^0-9])?(\d+)([^0-9])?")
+        id_match = re.compile(r"([^0-9])?(\d+)([^0-9])?")
         for nw in sp_trees:
             yield re.sub(id_match, _nodereplacer, str(nw)+";")
     else:
@@ -185,7 +185,7 @@ def iter_sptrees(sptrees, nid2node, features=None, newick_only=False):
         return ''.join([pre, node.name, fstring, post])
 
     if newick_only:
-        id_match = re.compile("([^0-9])(\d+)([^0-9])")
+        id_match = re.compile(r"([^0-9])(\d+)([^0-9])")
         for nw in sptrees:
             yield re.sub(id_match, _nodereplacer, str(nw)+";")
     else:

--- a/ete3/phylomedb/phylomeDB3.py
+++ b/ete3/phylomedb/phylomeDB3.py
@@ -72,7 +72,7 @@ from six.moves import map
 def extract_species_name(name):
   return name.split("_")[1]
 
-ID_PATTERN = re.compile("^[Pp][Hh][Yy]\w{7}(_\w{2,7})?$")
+ID_PATTERN = re.compile(r"^[Pp][Hh][Yy]\w{7}(_\w{2,7})?$")
 ITERABLE_TYPES = set([list, set, tuple, frozenset])
 
 __all__ = ["PhylomeDB3Connector"]
@@ -150,7 +150,7 @@ class Phylome(object):
     """
     def clean_name(name):
       quote = lambda x: '"%s"' %x
-      m = re.search("Phy(\w{7})_[\w\d]+", name)
+      m = re.search(r"Phy(\w{7})_[\w\d]+", name)
       if m:
         return quote(m.groups()[0])
 
@@ -497,7 +497,7 @@ class PhylomeDB3Connector(object):
     """
 
     # Check whether the input code is a valid former phylomeDB id or not
-    QUERY_OLD_REGEXP_FILTER = "^\w{3}\d{1,}$"
+    QUERY_OLD_REGEXP_FILTER = r"^\w{3}\d{1,}$"
     if not re.match(QUERY_OLD_REGEXP_FILTER, old_id):
       return None
 
@@ -753,9 +753,9 @@ class PhylomeDB3Connector(object):
     query = id.strip()
 
     # To avoid weird queries which creates slow or invalid MYSQL queries
-    QUERY_GEN_REGEXP_FILTER = "^[\w\d\-_,;:.|#@\/\\\()'<>!]+$"
-    QUERY_OLD_REGEXP_FILTER = "^\w{3}\d{1,}$"
-    QUERY_INT_REGEXP_FILTER = "^[Pp][Hh][Yy]\w{7}(_\w{2,7})?$"
+    QUERY_GEN_REGEXP_FILTER = r"^[\w\d\-_,;:.|#@/\\()'<>!]+$"
+    QUERY_OLD_REGEXP_FILTER = r"^\w{3}\d{1,}$"
+    QUERY_INT_REGEXP_FILTER = r"^[Pp][Hh][Yy]\w{7}(_\w{2,7})?$"
 
     phylomeDB_matches = {}
     # First, check if it is a current phylomeDB ID

--- a/ete3/tools/common.py
+++ b/ete3/tools/common.py
@@ -155,7 +155,7 @@ def shorten_str(string, l, reverse=False):
         return string
 
 def parse_value(fvalue):
-    func_match = re.search("(\w+)\(([^)]*)\)", fvalue)
+    func_match = re.search(r"(\w+)\(([^)]*)\)", fvalue)
     if func_match:
         func_name = func_match.groups()[0]
         func_arg = func_match.groups()[1]

--- a/ete3/tools/ete_view.py
+++ b/ete3/tools/ete_view.py
@@ -206,7 +206,7 @@ def run(args):
         for tindex, tfile in enumerate(src_tree_iterator(args)):
             #print tfile
             if args.raxml:
-                nw = re.sub(":(\d+\.\d+)\[(\d+)\]", ":\\1[&&NHX:support=\\2]", open(tfile).read())
+                nw = re.sub(r":(\d+\.\d+)\[(\d+)\]", r":\1[&&NHX:support=\2]", open(tfile).read())
                 t = Tree(nw, format=args.src_newick_format)
             else:
                 t = Tree(tfile, format=args.src_newick_format)
@@ -272,7 +272,7 @@ def run(args):
     for tindex, tfile in enumerate(src_tree_iterator(args)):
         #print tfile
         if args.raxml:
-            nw = re.sub(":(\d+\.\d+)\[(\d+)\]", ":\\1[&&NHX:support=\\2]", open(tfile).read())
+            nw = re.sub(r":(\d+\.\d+)\[(\d+)\]", r":\1[&&NHX:support=\2]", open(tfile).read())
             t = PhyloTree(nw, format=args.src_newick_format)
         else:
             t = PhyloTree(tfile, format=args.src_newick_format)
@@ -369,7 +369,7 @@ def run(args):
 
                             if fcolor:
                                 # Parse color options
-                                auto_m = re.search("auto\(([^)]*)\)", fcolor)
+                                auto_m = re.search(r"auto\(([^)]*)\)", fcolor)
                                 if auto_m:
                                     target_attr = auto_m.groups()[0].strip()
                                     if not target_attr :
@@ -389,7 +389,7 @@ def run(args):
 
                             if fbgcolor:
                                 # Parse color options
-                                auto_m = re.search("auto\(([^)]*)\)", fbgcolor)
+                                auto_m = re.search(r"auto\(([^)]*)\)", fbgcolor)
                                 if auto_m:
                                     target_attr = auto_m.groups()[0].strip()
                                     if not target_attr :

--- a/ete3/tools/utils.py
+++ b/ete3/tools/utils.py
@@ -25,7 +25,7 @@ def colorify(string, color):
     return "%s%s%s" %(COLORS[color], string, COLORS[None])
 
 def clear_color(string):
-    return re.sub("\\033\[[^m]+m", "", string)
+    return re.sub(r"\033\[[^m]+m", "", string)
 
 def which(program):
     def is_exe(fpath):

--- a/ete3/treeview/faces.py
+++ b/ete3/treeview/faces.py
@@ -156,7 +156,7 @@ __all__ = ["Face", "TextFace", "AttrFace", "ImgFace",
            "RectFace", "StackedBarFace", "SVGFace", "DiamondFace"]
 
 class Face(object):
-    """Base Face object. All Face types (i.e. TextFace, SeqMotifFace,
+    r"""Base Face object. All Face types (i.e. TextFace, SeqMotifFace,
     etc.) inherit the following options:
 
     :param 0 margin_left: in pixels

--- a/ete3/treeview/main.py
+++ b/ete3/treeview/main.py
@@ -61,7 +61,7 @@ def tracktime(f):
 
 _LINE_TYPE_CHECKER = lambda x: x in (0,1,2)
 _SIZE_CHECKER = lambda x: isinstance(x, int)
-_COLOR_MATCH = re.compile("^#[A-Fa-f\d]{6}$")
+_COLOR_MATCH = re.compile(r"^#[A-Fa-f\d]{6}$")
 _COLOR_CHECKER = lambda x: x.lower() in SVG_COLORS or re.match(_COLOR_MATCH, x)
 _NODE_TYPE_CHECKER = lambda x: x in ["sphere", "circle", "square"]
 _BOOL_CHECKER =  lambda x: isinstance(x, bool) or x in (0,1)
@@ -713,9 +713,9 @@ def save(scene, imgName, w=None, h=None, dpi=90,\
         # Fix a very annoying problem with Radial gradients in
         # inkscape and browsers...
         compatible_code = compatible_code.replace("xml:id=", "id=")
-        compatible_code = re.sub('font-size="(\d+)"', 'font-size="\\1pt"', compatible_code)
+        compatible_code = re.sub(r'font-size="(\d+)"', r'font-size="\1pt"', compatible_code)
         compatible_code = compatible_code.replace('\n', ' ')
-        compatible_code = re.sub('<g [^>]+>\s*</g>', '', compatible_code)
+        compatible_code = re.sub(r'<g [^>]+>\s*</g>', '', compatible_code)
         # End of fix
         if ipython_inline:
             from IPython.core.display import SVG

--- a/ete3/utils.py
+++ b/ete3/utils.py
@@ -79,7 +79,7 @@ def color(string, color):
     return "%s%s%s" %(SHELL_COLORS[color], string, SHELL_COLORS[None])
 
 def clear_color(string):
-    return re.sub("\\033\[[^m]+m", "", string)
+    return re.sub(r"\033\[[^m]+m", "", string)
 
 def print_table(items, header=None, wrap=True, max_col_width=20,
                 wrap_style="wrap", row_line=False, fix_col_width=False, title=None):


### PR DESCRIPTION
## Summary
- convert the invalid escape sequence regex literals reported in #771 to raw strings
- make affected documentation strings raw where their ASCII tree examples intentionally contain backslashes
- keep control-character literals such as tab/newline/carriage return intact where they are part of parser character sets

Fixes #771.

## Validation
- `git diff --check`
- Not run locally
