### PR TITLE
Allow downloading non-default taxdump file for NCBITaxa

### DIFF
--- a/ete4/ncbi_taxonomy/ncbiquery.py
+++ b/ete4/ncbi_taxonomy/ncbiquery.py
@@ -674,8 +674,8 @@ def update_db(dbfile, targz_file=None):
         os.makedirs(basepath)
 
     if not targz_file:
-        update_local_taxdump(DEFAULT_TAXDUMP)
         targz_file = DEFAULT_TAXDUMP
+    update_local_taxdump(targz_file)
 
     tar = tarfile.open(targz_file, 'r')
     t, synonyms = load_ncbi_tree_from_dump(tar)

--- a/tests/slow/test_ncbiquery_force_download.py
+++ b/tests/slow/test_ncbiquery_force_download.py
@@ -2,6 +2,10 @@
 Test the functionality of ncbiquery.py. To run with pytest.
 """
 
+import os
+
+import pytest
+
 from ete4 import ETE_DATA_HOME
 from ete4.ncbi_taxonomy import ncbiquery
 
@@ -12,3 +16,17 @@ def test_update_database():
     ncbiquery.update_db(DATABASE_PATH)
     # It will download the full NCBI taxa database and process it. Slow!
     # Should raise an error if things go wrong.
+
+@pytest.fixture(autouse=True)
+def clean_taxdump():
+    # remove the taxdump if it exists
+    taxdump_location = ETE_DATA_HOME + '/tests/test_ncbiquery.taxdump.tar.gz'
+    if os.path.exists(taxdump_location):
+        os.remove(taxdump_location)
+
+def test_update_with_taxdump():
+    # update the db while using a custom location for the taxdump
+    taxdump_location = ETE_DATA_HOME + '/tests/test_ncbiquery.taxdump.tar.gz'
+    assert not os.path.exists(taxdump_location)
+    ncbiquery.update_db(DATABASE_PATH, taxdump_location)
+    assert os.path.exists(taxdump_location)

--- a/tests/test_ncbiquery.py
+++ b/tests/test_ncbiquery.py
@@ -122,7 +122,7 @@ def test_ncbiquery():
     assert set(out) == {63221, 741158, 2665953, 1425170, 2813599}
 
     out = ncbi.get_descendant_taxa('9596', intermediate_nodes=False, rank_limit='species')
-    assert set(out) == {9597, 9598}
+    assert set(out) == {9597, 9598, 3612878}
 
 
 def test_get_topology():


### PR DESCRIPTION
Currently, when initializing `NCBITaxa` with a non-default `taxdump_file`, ete4 will not download the taxdump to that location if it doesn't already exist, leading to an error. This breaks using ete4 for taxonomy handling in a Snakemake pipelin on a cluster for me. 

In order to allow downloading a taxdump to a non-default location, I've changed the logic in `update_db` so it will always run `update_local_taxdump` (can change that to only update if it doesn't exist if there's a use case for having a "frozen" taxdump that you download once and never touch?). I've also added a test for that (not run by default, as it downloads the files it's one of the slow tests).  

(Have also tweaked the expected output of getting species-level descendant taxa for *Pan*, as there now is [a third species-level descendant taxon](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?command=show&mode=node&id=3612878&lvl=3) *Pan* sp..)